### PR TITLE
fix(cmake): add SDL2_ttf via CPM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,10 +64,17 @@ CPMAddPackage(
         "SDL_EXAMPLES OFF"
 )
 
+CPMAddPackage(
+    NAME SDL2_ttf
+    GITHUB_REPOSITORY libsdl-org/SDL_ttf
+    GIT_TAG release-2.22.0
+    OPTIONS
+        "SDL2TTF_SAMPLES OFF"
+)
+
 # OpenSSL / FreeType
 find_package(OpenSSL REQUIRED)
 find_package(Freetype REQUIRED)
-find_package(SDL2_ttf REQUIRED)
 
 # ------------------------------------------------------------------------------
 # Skia (external build)


### PR DESCRIPTION
Fix #5 

Use CPM to fetch SDL2_ttf instead of relying on system packages.

This avoids missing SDL2_ttfConfig.cmake on Debian-based systems and makes the build more portable and reproducible.