### PR TITLE
feat: implement CSS engine with cascade, inheritance, and style computation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,10 @@ add_executable(c_surfer
     src/request/HttpRequest.cpp
     src/utils/Parser.cpp
     src/browser/Browser.cpp
+    src/css/CSSSelector.cpp
+    src/css/CSSParser.cpp
+    src/css/StyleComputation.cpp
+    src/css/StyleEngine.cpp
 )
 
 # Add include directories for src/

--- a/pages/css.css
+++ b/pages/css.css
@@ -1,0 +1,20 @@
+body {
+    background-color: yellow;
+}
+
+h1 {
+    color: green;
+}
+
+p {
+    font-size: 20px;
+}
+
+div p {
+    font-style: italic;
+    color: red;
+}
+
+b {
+    color: red;
+}

--- a/pages/css.html
+++ b/pages/css.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <link rel="stylesheet" href="test_style.css">
+</head>
+
+<body>
+    <h1>Chapter 6: CSS Test</h1>
+    <p>This paragraph should be styled by the external CSS.</p>
+    <div>
+        <p>This paragraph is a descendant of a div.</p>
+    </div>
+    <div style="background-color: blue;">
+        This div uses inline styles to set its background to blue.
+    </div>
+    <b>This is a bold tag (should be bold and red based on CSS).</b>
+</body>
+
+</html>

--- a/pages/css.html
+++ b/pages/css.html
@@ -2,7 +2,7 @@
 <html>
 
 <head>
-    <link rel="stylesheet" href="test_style.css">
+    <link rel="stylesheet" href="css.css">
 </head>
 
 <body>

--- a/src/browser/Browser.cpp
+++ b/src/browser/Browser.cpp
@@ -1,4 +1,5 @@
 #include "Browser.h"
+#include "css/StyleEngine.h"
 #include "html/HTMLParser.h"
 #include "layout/LayoutConstants.h"
 #include "layout/LayoutTree.h"
@@ -94,6 +95,11 @@ void Browser::load(const Url &url) {
   // Extract font metrics
   FontMetrics metrics{TTF_FontAscent(font), abs(TTF_FontDescent(font)),
                       TTF_FontLineSkip(font)};
+
+  // Apply all CSS: default styles, external stylesheets, inline styles.
+  // Specificity-based cascade is handled inside StyleEngine.
+  StyleEngine style_engine(http_);
+  style_engine.apply(dynamic_cast<Element *>(root_.get()), url);
 
   // Build a layout tree for the parsed HTML and compute positions.
   document_ = std::make_unique<DocumentLayout>(root_.get(), metrics, WIDTH);

--- a/src/css/CSSParser.cpp
+++ b/src/css/CSSParser.cpp
@@ -1,0 +1,131 @@
+#include "CSSParser.h"
+#include <algorithm>
+#include <cctype>
+#include <stdexcept>
+
+CSSParser::CSSParser(std::string css_text)
+    : text_(std::move(css_text)), pos_(0) {}
+
+void CSSParser::whitespace() {
+  while (pos_ < text_.length() &&
+         std::isspace(static_cast<unsigned char>(text_[pos_]))) {
+    pos_++;
+  }
+}
+
+void CSSParser::literal(char c) {
+  if (pos_ < text_.length() && text_[pos_] == c) {
+    pos_++;
+  } else {
+    throw std::runtime_error("Parsing error: expected literal");
+  }
+}
+
+std::string CSSParser::word() {
+  size_t start = pos_;
+  while (pos_ < text_.length()) {
+    char c = text_[pos_];
+    if (std::isalnum(static_cast<unsigned char>(c)) || c == '#' || c == '-' ||
+        c == '.' || c == '%') {
+      pos_++;
+    } else {
+      break;
+    }
+  }
+  if (pos_ == start) {
+    throw std::runtime_error("Parsing error: expected word");
+  }
+  return text_.substr(start, pos_ - start);
+}
+
+// Convert a string to lowercase to handle case-insensitive properties
+static std::string casefold(std::string s) {
+  std::transform(s.begin(), s.end(), s.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+  return s;
+}
+
+std::pair<std::string, std::string> CSSParser::pair() {
+  std::string prop = word();
+  whitespace();
+  literal(':');
+  whitespace();
+  std::string val = word();
+  return {casefold(prop), val};
+}
+
+char CSSParser::ignore_until(const std::vector<char> &chars) {
+  while (pos_ < text_.length()) {
+    char c = text_[pos_];
+    if (std::find(chars.begin(), chars.end(), c) != chars.end()) {
+      return c;
+    }
+    pos_++;
+  }
+  return '\0'; // Return null char if end of string is reached
+}
+
+std::unordered_map<std::string, std::string> CSSParser::body() {
+  std::unordered_map<std::string, std::string> pairs;
+  while (pos_ < text_.length() && text_[pos_] != '}') {
+    try {
+      auto p = pair();
+      pairs[p.first] = p.second;
+      whitespace();
+      literal(';');
+      whitespace();
+    } catch (const std::exception &e) {
+      char why = ignore_until({';', '}'});
+      if (why == ';') {
+        literal(';');
+        whitespace();
+      } else {
+        break;
+      }
+    }
+  }
+  return pairs;
+}
+
+std::shared_ptr<CSSSelector> CSSParser::selector() {
+  std::string tag = casefold(word());
+  std::shared_ptr<CSSSelector> out = std::make_shared<TagSelector>(tag);
+  whitespace();
+
+  while (pos_ < text_.length() && text_[pos_] != '{') {
+    std::string descendant_tag = casefold(word());
+    std::shared_ptr<CSSSelector> descendant =
+        std::make_shared<TagSelector>(descendant_tag);
+    out = std::make_shared<DescendantSelector>(out, descendant);
+    whitespace();
+  }
+  return out;
+}
+
+std::vector<CSSRule> CSSParser::parse() {
+  std::vector<CSSRule> rules;
+  while (pos_ < text_.length()) {
+    try {
+      whitespace();
+      if (pos_ >= text_.length())
+        break;
+
+      auto sel = selector();
+      literal('{');
+      whitespace();
+      auto b = body();
+      literal('}');
+
+      rules.push_back({sel, b});
+    } catch (const std::exception &e) {
+      char why = ignore_until({'}'});
+      if (why == '}') {
+        literal('}');
+        whitespace();
+      } else {
+        break;
+      }
+    }
+  }
+  return rules;
+}

--- a/src/css/CSSParser.h
+++ b/src/css/CSSParser.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "CSSRule.h"
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+class CSSParser {
+public:
+  explicit CSSParser(std::string css_text);
+
+  // Parses the entire CSS string provided in the constructor.
+  std::vector<CSSRule> parse();
+
+private:
+  void whitespace();
+  void literal(char c);
+  std::string word();
+  std::pair<std::string, std::string> pair();
+  std::unordered_map<std::string, std::string> body();
+  std::shared_ptr<CSSSelector> selector();
+
+  // Helper to recover from parsing errors by ignoring characters up to certain
+  // stops.
+  char ignore_until(const std::vector<char> &chars);
+
+  std::string text_;
+  size_t pos_;
+};

--- a/src/css/CSSRule.h
+++ b/src/css/CSSRule.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "CSSSelector.h"
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+// Represents a single parsed CSS rule block.
+// Example: p { color: blue; font-size: 16px; }
+struct CSSRule {
+  std::shared_ptr<CSSSelector> selector;
+  std::unordered_map<std::string, std::string> declarations;
+};

--- a/src/css/CSSSelector.cpp
+++ b/src/css/CSSSelector.cpp
@@ -1,0 +1,44 @@
+#include "CSSSelector.h"
+#include "../lexer/Element.h"
+
+// TagSelector Implementation
+TagSelector::TagSelector(std::string tag)
+    : tag_(std::move(tag)), priority_(1) {}
+
+bool TagSelector::matches(const Element *element) const {
+  if (!element)
+    return false;
+  return element->tag() == tag_;
+}
+
+int TagSelector::priority() const { return priority_; }
+
+// DescendantSelector Implementation
+DescendantSelector::DescendantSelector(std::shared_ptr<CSSSelector> ancestor,
+                                       std::shared_ptr<CSSSelector> descendant)
+    : ancestor_(std::move(ancestor)), descendant_(std::move(descendant)) {
+  priority_ = (ancestor_ ? ancestor_->priority() : 0) +
+              (descendant_ ? descendant_->priority() : 0);
+}
+
+bool DescendantSelector::matches(const Element *element) const {
+  if (!element)
+    return false;
+
+  // The target element must first match the descendant selector part
+  if (!descendant_ || !descendant_->matches(element)) {
+    return false;
+  }
+
+  // Traverse upwards to see if any ancestor matches the ancestor selector part
+  Element *current = element->parent();
+  while (current) {
+    if (ancestor_ && ancestor_->matches(current)) {
+      return true;
+    }
+    current = current->parent();
+  }
+  return false;
+}
+
+int DescendantSelector::priority() const { return priority_; }

--- a/src/css/CSSSelector.h
+++ b/src/css/CSSSelector.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+// Forward declaration of Element to avoid including full header here
+class Element;
+
+class CSSSelector {
+public:
+  virtual ~CSSSelector() = default;
+
+  // Checks if this selector matches a given Element.
+  virtual bool matches(const Element *element) const = 0;
+
+  // Returns the specificity/priority of the selector for cascade sorting.
+  virtual int priority() const = 0;
+};
+
+// Matches elements by their HTML tag name (e.g., "div", "a").
+class TagSelector : public CSSSelector {
+public:
+  explicit TagSelector(std::string tag);
+
+  bool matches(const Element *element) const override;
+  int priority() const override;
+
+private:
+  std::string tag_;
+  int priority_;
+};
+
+// Matches an element if it is a descendant of another matched element (e.g.,
+// "div p").
+class DescendantSelector : public CSSSelector {
+public:
+  DescendantSelector(std::shared_ptr<CSSSelector> ancestor,
+                     std::shared_ptr<CSSSelector> descendant);
+
+  bool matches(const Element *element) const override;
+  int priority() const override;
+
+private:
+  std::shared_ptr<CSSSelector> ancestor_;
+  std::shared_ptr<CSSSelector> descendant_;
+  int priority_;
+};

--- a/src/css/DefaultStyles.h
+++ b/src/css/DefaultStyles.h
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace CSS {
+
+const char *const DEFAULT_BROWSER_CSS = R"(
+    h1 { font-size: 2em; font-weight: bold; }
+    h2 { font-size: 1.5em; font-weight: bold; }
+    i { font-style: italic; }
+    b { font-weight: bold; }
+    small { font-size: 80%; }
+    big { font-size: 120%; }
+    a { color: blue; text-decoration: underline; }
+)";
+
+} // namespace CSS

--- a/src/css/StyleComputation.cpp
+++ b/src/css/StyleComputation.cpp
@@ -1,0 +1,104 @@
+#include "StyleComputation.h"
+#include "CSSParser.h"
+
+namespace CSS {
+
+static const std::unordered_map<std::string, std::string> INHERITED_PROPERTIES =
+    {
+        {"font-size", "16px"},
+        {"font-style", "normal"},
+        {"font-weight", "normal"},
+        {"color", "black"},
+};
+
+void computeStyle(Element *node, const std::vector<CSSRule> &rules) {
+  if (!node)
+    return;
+
+  // 1. Inheritance
+  for (const auto &[property, default_value] : INHERITED_PROPERTIES) {
+    if (node->parent()) {
+      auto parent_style = node->parent()->style();
+      if (parent_style.find(property) != parent_style.end()) {
+        node->addStyle(property, parent_style[property]);
+      } else {
+        node->addStyle(property, default_value);
+      }
+    } else {
+      node->addStyle(property, default_value);
+    }
+  }
+
+  // 2. Cascading Rules
+  for (const auto &rule : rules) {
+    if (rule.selector && rule.selector->matches(node)) {
+      for (const auto &[property, value] : rule.declarations) {
+        node->addStyle(property, value);
+      }
+    }
+  }
+
+  // 3. Inline Styles
+  auto attrs = node->attributes();
+  if (attrs.find("style") != attrs.end()) {
+    try {
+      CSSParser parser(attrs["style"]);
+      // We use a dummy selector just to reuse the parser's body() logic via
+      // parse() Wait, CSSParser::parse expects a full rule `selector { body }`.
+      // For inline style, we just want to parse the body.
+      // Actually, CSSParser doesn't expose `body()` publicly. Let's wrap it in
+      // a dummy bracket.
+      std::string dummy_css = "dummy {" + attrs["style"] + "}";
+      CSSParser inlineParser(dummy_css);
+      auto inlineRules = inlineParser.parse();
+      if (!inlineRules.empty()) {
+        for (const auto &[property, value] : inlineRules[0].declarations) {
+          node->addStyle(property, value);
+        }
+      }
+    } catch (...) {
+      // Ignore malformed inline styles
+    }
+  }
+
+  // 4. Compute relative values (Percentages for font-size)
+  auto current_style = node->style();
+  if (current_style.find("font-size") != current_style.end()) {
+    std::string font_size = current_style["font-size"];
+    if (!font_size.empty() && font_size.back() == '%') {
+      std::string parent_font_size = INHERITED_PROPERTIES.at("font-size");
+      if (node->parent()) {
+        auto p_style = node->parent()->style();
+        if (p_style.find("font-size") != p_style.end()) {
+          parent_font_size = p_style["font-size"];
+        }
+      }
+
+      try {
+        double pct =
+            std::stod(font_size.substr(0, font_size.length() - 1)) / 100.0;
+        // remove "px" from parent string
+        double parent_px = 16.0;
+        if (parent_font_size.length() > 2 &&
+            parent_font_size.substr(parent_font_size.length() - 2) == "px") {
+          parent_px = std::stod(
+              parent_font_size.substr(0, parent_font_size.length() - 2));
+        }
+
+        std::string computed_size = std::to_string(pct * parent_px) + "px";
+        node->addStyle("font-size", computed_size);
+      } catch (...) {
+        // Ignore conversion errors
+      }
+    }
+  }
+
+  // 5. Recursion
+  for (const auto &child : node->children()) {
+    if (auto *child_elem = dynamic_cast<Element *>(child.get())) {
+      computeStyle(child_elem, rules);
+    }
+  }
+}
+
+} // namespace CSS

--- a/src/css/StyleComputation.h
+++ b/src/css/StyleComputation.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "../lexer/Element.h"
+#include "CSSRule.h"
+#include <vector>
+
+namespace CSS {
+
+// Recursively walks the DOM tree starting at 'node'.
+// For each element, it applies inherited properties from its parent,
+// checks all 'rules' to see which match, and applies inline "style" attributes.
+// Finally, computes relative sizes (e.g. 90% font-size -> absolute pixels).
+void computeStyle(Element *node, const std::vector<CSSRule> &rules);
+
+} // namespace CSS

--- a/src/css/StyleEngine.cpp
+++ b/src/css/StyleEngine.cpp
@@ -1,0 +1,97 @@
+#include "StyleEngine.h"
+
+#include "CSSParser.h"
+#include "CSSRule.h"
+#include "DefaultStyles.h"
+#include "StyleComputation.h"
+#include "lexer/Element.h"
+#include "lexer/Lexeme.h"
+
+#include <algorithm>
+#include <functional>
+#include <iostream>
+
+StyleEngine::StyleEngine(std::shared_ptr<IRequest> http)
+    : http_(std::move(http)) {}
+
+// Recursively collect all <link rel="stylesheet" href="..."> elements.
+//
+// We walk the entire DOM tree because <link> can theoretically appear
+// anywhere (though it's usually in <head>).
+//
+// Example: finds <link rel="stylesheet" href="style.css"> → returns its href
+static std::vector<std::string>
+collectStylesheetHrefs(const Element *root) {
+  std::vector<std::string> hrefs;
+
+  std::function<void(const Lexeme *)> walk = [&](const Lexeme *node) {
+    if (!node)
+      return;
+    if (node->type() == LexemeType::Element) {
+      const auto *el = dynamic_cast<const Element *>(node);
+      if (!el)
+        return;
+
+      if (el->tag() == "link") {
+        auto attrs = el->attributes();
+        if (attrs.count("rel") && attrs.at("rel") == "stylesheet" &&
+            attrs.count("href")) {
+          hrefs.push_back(attrs.at("href"));
+        }
+      }
+
+      for (const auto &child : el->children()) {
+        walk(child.get());
+      }
+    }
+  };
+
+  walk(root);
+  return hrefs;
+}
+
+// Sort CSS rules so lower-specificity rules come first.
+// This ensures higher-specificity rules always overwrite lower ones
+// when computeStyle iterates through the list in order.
+//
+// Example:
+//   h1 { color: black }     → specificity 1  (comes first)
+//   body h1 { color: green} → specificity 2  (overwrites above)
+static void sortBySpecificity(std::vector<CSSRule> &rules) {
+  std::stable_sort(rules.begin(), rules.end(),
+                   [](const CSSRule &a, const CSSRule &b) {
+                     int pA = a.selector ? a.selector->priority() : 0;
+                     int pB = b.selector ? b.selector->priority() : 0;
+                     return pA < pB;
+                   });
+}
+
+void StyleEngine::apply(Element *root, const Url &base_url) {
+  if (!root)
+    return;
+
+  // Step 1: Start with the default browser stylesheet (h1, b, i, etc.)
+  CSSParser default_parser(CSS::DEFAULT_BROWSER_CSS);
+  std::vector<CSSRule> rules = default_parser.parse();
+
+  // Step 2: Find and fetch external stylesheets from <link> elements
+  auto hrefs = collectStylesheetHrefs(root);
+  for (const auto &href : hrefs) {
+    try {
+      Url style_url = base_url.resolve(href);
+      std::string css_text = http_->request(style_url);
+      CSSParser parser(css_text);
+      auto extra = parser.parse();
+      rules.insert(rules.end(), extra.begin(), extra.end());
+    } catch (const std::exception &e) {
+      std::cerr << "[StyleEngine] Failed to load stylesheet: " << href
+                << " — " << e.what() << "\n";
+    }
+  }
+
+  // Step 3: Sort all rules by specificity (ascending)
+  sortBySpecificity(rules);
+
+  // Step 4: Walk the DOM and compute each element's final style map
+  CSS::computeStyle(root, rules);
+}

--- a/src/css/StyleEngine.h
+++ b/src/css/StyleEngine.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "request/IRequest.h"
+#include "url/Url.h"
+#include <memory>
+
+class Element;
+
+// StyleEngine — the single entry point for all CSS processing.
+//
+// Encapsulates the entire CSS pipeline so the Browser doesn't need
+// to know how CSS works internally. Just call apply() after parsing HTML.
+//
+// The pipeline (all hidden from the caller):
+//   1. Parse the default browser stylesheet
+//   2. Find <link rel="stylesheet"> elements in the DOM
+//   3. Fetch and parse each external stylesheet via http
+//   4. Sort all rules by selector specificity (ascending)
+//   5. Walk the DOM and compute each element's final styles
+//
+// Example:
+//   StyleEngine engine(http_client);
+//   engine.apply(root_element, page_url);
+//
+class StyleEngine {
+public:
+  explicit StyleEngine(std::shared_ptr<IRequest> http);
+
+  // Apply all CSS rules to the DOM tree rooted at `root`.
+  // `base_url` is used to resolve relative <link href="..."> paths.
+  void apply(Element *root, const Url &base_url);
+
+private:
+  std::shared_ptr<IRequest> http_;
+};

--- a/src/html/HTMLParser.cpp
+++ b/src/html/HTMLParser.cpp
@@ -4,7 +4,6 @@
 #include <algorithm>
 #include <cctype>
 #include <iostream>
-#include <sstream>
 #include <string_view>
 
 namespace {
@@ -103,32 +102,58 @@ std::unique_ptr<Element> HTMLParser::parse() {
 // "https://example.com"})
 std::pair<std::string, Element::AttributeMap>
 HTMLParser::get_attributes(const std::string &text) const {
-  std::istringstream iss(text);
-  std::vector<std::string> parts;
-  std::string part;
-  while (iss >> part) {
-    parts.push_back(part);
-  }
-
-  if (parts.empty()) {
+  if (text.empty()) {
     return {"", {}};
   }
 
-  std::string tag = to_lower(parts[0]);
+  size_t i = 0;
+  while (i < text.size() && !std::isspace(static_cast<unsigned char>(text[i]))) {
+    i++;
+  }
+  std::string tag = to_lower(text.substr(0, i));
+
   Element::AttributeMap attributes;
 
-  for (size_t i = 1; i < parts.size(); i++) {
-    const std::string &attrpair = parts[i];
-    auto eq = attrpair.find('=');
-    if (eq != std::string::npos) {
-      std::string key = to_lower(attrpair.substr(0, eq));
-      std::string value = attrpair.substr(eq + 1);
-      if (value.size() > 2 && (value.front() == '\'' || value.front() == '"')) {
-        value = value.substr(1, value.size() - 2);
+  while (i < text.size()) {
+    while (i < text.size() && std::isspace(static_cast<unsigned char>(text[i]))) {
+      i++;
+    }
+    if (i >= text.size()) break;
+
+    size_t name_start = i;
+    while (i < text.size() && text[i] != '=' && !std::isspace(static_cast<unsigned char>(text[i]))) {
+      i++;
+    }
+    std::string key = to_lower(text.substr(name_start, i - name_start));
+
+    while (i < text.size() && std::isspace(static_cast<unsigned char>(text[i]))) {
+      i++;
+    }
+
+    if (i < text.size() && text[i] == '=') {
+      i++; // skip '='
+      while (i < text.size() && std::isspace(static_cast<unsigned char>(text[i]))) {
+        i++;
       }
-      attributes[to_lower(key)] = value;
+
+      if (i < text.size() && (text[i] == '"' || text[i] == '\'')) {
+        char quote = text[i];
+        i++;
+        size_t val_start = i;
+        while (i < text.size() && text[i] != quote) {
+          i++;
+        }
+        attributes[key] = text.substr(val_start, i - val_start);
+        if (i < text.size()) i++; // skip closing quote
+      } else {
+        size_t val_start = i;
+        while (i < text.size() && !std::isspace(static_cast<unsigned char>(text[i]))) {
+          i++;
+        }
+        attributes[key] = text.substr(val_start, i - val_start);
+      }
     } else {
-      attributes[to_lower(attrpair)] = "";
+      attributes[key] = "";
     }
   }
 

--- a/src/layout/BlockLayout.cpp
+++ b/src/layout/BlockLayout.cpp
@@ -1,11 +1,12 @@
 #include "layout/BlockLayout.h"
 
-#include "layout/LayoutConstants.h"
+#include "lexer/Text.h"
 #include "utils/Parser.h"
 
 #include <SDL2/SDL_ttf.h>
 #include <algorithm>
 #include <cmath>
+#include <iostream>
 #include <unordered_set>
 
 static const std::unordered_set<std::string> BLOCK_ELEMENTS = {
@@ -83,9 +84,6 @@ void BlockLayout::layout() {
   } else {
     cursor_x_ = 0;
     cursor_y_ = 0;
-    bold_ = false;
-    italic_ = false;
-    font_size_ = 16;
     recurse(node_);
     flush();
   }
@@ -107,16 +105,35 @@ void BlockLayout::layout() {
 
 void BlockLayout::paint(std::vector<std::unique_ptr<DrawCommand>> &out) const {
   const auto *el = dynamic_cast<const Element *>(node_);
-  if (el && el->tag() == "pre") {
-    SDL_Color gray{200, 200, 200, 255};
-    out.push_back(
-        std::make_unique<DrawRect>(x, y, x + width, y + height, gray));
+  if (el) {
+    auto styles = el->style();
+    if (styles.find("background-color") != styles.end()) {
+      std::string bgcolor = styles.at("background-color");
+      if (bgcolor != "transparent" && !bgcolor.empty()) {
+        // Very simple color parsing for now (assuming named colors or hex)
+        // Just map some basic colors to prove it works
+        SDL_Color color{200, 200, 200, 255}; // Default Gray
+        if (bgcolor == "blue")
+          color = {0, 0, 255, 255};
+        else if (bgcolor == "red")
+          color = {255, 0, 0, 255};
+        else if (bgcolor == "green")
+          color = {0, 255, 0, 255};
+        else if (bgcolor == "yellow")
+          color = {255, 255, 0, 255};
+        else if (bgcolor == "black")
+          color = {0, 0, 0, 255};
+
+        out.push_back(
+            std::make_unique<DrawRect>(x, y, x + width, y + height, color));
+      }
+    }
   }
 
   if (layout_mode() == LayoutMode::Inline) {
     for (const auto &item : display_list_) {
-      out.push_back(
-          std::make_unique<DrawText>(item.x, item.y, item.text, item.font));
+      out.push_back(std::make_unique<DrawText>(item.x, item.y, item.text,
+                                               item.font, item.color));
     }
   }
 }
@@ -128,12 +145,23 @@ void BlockLayout::layoutNode(const Lexeme *node) {
     return;
 
   if (node->type() == LexemeType::Text) {
-    layoutText(node->text());
+    // A Text node itself doesn't have styles, its parent does.
+    const Element *parent_el = nullptr;
+    // We need to trace back from LayoutTree or find parent in DOM.
+    // Lexeme doesn't have parent() in the interface, but Element/Text do.
+    // Fortunately Text has parent(). But node is a Lexeme*.
+    if (const auto *t = dynamic_cast<const Text *>(node)) {
+      parent_el = dynamic_cast<const Element *>(t->parent());
+    }
+    layoutText(node->text(), parent_el);
     return;
   }
 
   if (node->type() == LexemeType::Element) {
     const auto *el = dynamic_cast<const Element *>(node);
+    if (el && el->tag() == "br") {
+      flush();
+    }
     layoutElement(el);
   }
 }
@@ -142,58 +170,26 @@ void BlockLayout::layoutElement(const Element *element) {
   if (!element)
     return;
 
-  const std::string &tag = element->tag();
-  open_tag(tag);
-
   for (const auto &child : element->children()) {
     layoutNode(child.get());
   }
-
-  close_tag(tag);
 }
 
-void BlockLayout::open_tag(const std::string &tag) {
-  if (tag == "b") {
-    bold_ = true;
-  } else if (tag == "i") {
-    italic_ = true;
-  } else if (tag == "small") {
-    font_size_ -= 2;
-  } else if (tag == "big") {
-    font_size_ += 4;
-  } else if (tag == "br") {
-    flush();
-  }
-}
-
-void BlockLayout::close_tag(const std::string &tag) {
-  if (tag == "b") {
-    bold_ = false;
-  } else if (tag == "i") {
-    italic_ = false;
-  } else if (tag == "small") {
-    font_size_ += 2;
-  } else if (tag == "big") {
-    font_size_ -= 4;
-  } else if (tag == "p") {
-    flush();
-    cursor_y_ += metrics_.lineSkip;
-  }
-}
-
-void BlockLayout::layoutText(const std::string &text) {
+void BlockLayout::layoutText(const std::string &text,
+                             const Element *parent_element) {
   auto words = utils::splitWords(text);
   for (const auto &w : words) {
     if (w == "\n") {
       flush();
       continue;
     }
-    word(w);
+    word(w, parent_element);
   }
 }
 
-void BlockLayout::word(const std::string &word_text) {
-  TTF_Font *font = currentFont();
+void BlockLayout::word(const std::string &word_text,
+                       const Element *parent_element) {
+  TTF_Font *font = currentFont(parent_element);
   if (!font)
     return;
 
@@ -205,7 +201,21 @@ void BlockLayout::word(const std::string &word_text) {
     flush();
   }
 
-  line_.push_back({cursor_x_, word_text, font});
+  SDL_Color current_color = {0, 0, 0, 255}; // Default black
+  if (parent_element) {
+    auto styles = parent_element->style();
+    if (styles.find("color") != styles.end()) {
+      std::string c_str = styles.at("color");
+      if (c_str == "red") current_color = {255, 0, 0, 255};
+      else if (c_str == "green") current_color = {0, 128, 0, 255}; // web green is darker, let's just use 128 or 255.
+      else if (c_str == "blue") current_color = {0, 0, 255, 255};
+      else if (c_str == "yellow") current_color = {255, 255, 0, 255};
+      else if (c_str == "white") current_color = {255, 255, 255, 255};
+      else if (c_str == "black") current_color = {0, 0, 0, 255};
+    }
+  }
+
+  line_.push_back({cursor_x_, word_text, font, current_color});
 
   int space_w = 0;
   TTF_SizeUTF8(font, " ", &space_w, nullptr);
@@ -229,7 +239,8 @@ void BlockLayout::flush() {
   for (const auto &item : line_) {
     int abs_x = x + item.rel_x;
     int abs_y = y + baseline - TTF_FontAscent(item.font);
-    display_list_.push_back({abs_x, abs_y, item.text, item.font});
+
+    display_list_.push_back({abs_x, abs_y, item.text, item.font, item.color});
   }
 
   cursor_y_ = baseline + static_cast<int>(1.25 * max_descent);
@@ -237,22 +248,47 @@ void BlockLayout::flush() {
   line_.clear();
 }
 
-TTF_Font *BlockLayout::currentFont() {
+TTF_Font *BlockLayout::currentFont(const Element *element) {
   std::string font_path =
       std::string(ASSETS_DIR) + "/fonts/NotoSansCJK-Regular.ttc";
 
-  FontKey key{font_size_, bold_, italic_};
+  int f_size = 16;
+  bool f_bold = false;
+  bool f_italic = false;
+
+  if (element) {
+    auto styles = element->style();
+    if (styles.find("font-size") != styles.end()) {
+      std::string fs = styles.at("font-size");
+      if (fs.length() > 2 && fs.substr(fs.length() - 2) == "px") {
+        try {
+          f_size = std::stoi(fs.substr(0, fs.length() - 2));
+        } catch (...) {
+        }
+      }
+    }
+    if (styles.find("font-weight") != styles.end() &&
+        styles.at("font-weight") == "bold") {
+      f_bold = true;
+    }
+    if (styles.find("font-style") != styles.end() &&
+        styles.at("font-style") == "italic") {
+      f_italic = true;
+    }
+  }
+
+  FontKey key{f_size, f_bold, f_italic};
   if (font_cache_.contains(key))
     return font_cache_[key];
 
-  TTF_Font *font = TTF_OpenFont(font_path.c_str(), font_size_);
+  TTF_Font *font = TTF_OpenFont(font_path.c_str(), f_size);
   if (!font)
     return nullptr;
 
   int style = TTF_STYLE_NORMAL;
-  if (bold_)
+  if (f_bold)
     style |= TTF_STYLE_BOLD;
-  if (italic_)
+  if (f_italic)
     style |= TTF_STYLE_ITALIC;
   TTF_SetFontStyle(font, style);
 

--- a/src/layout/BlockLayout.h
+++ b/src/layout/BlockLayout.h
@@ -17,6 +17,7 @@ struct LineItem {
   int rel_x;        // relative to the block
   std::string text; // UTF-8
   TTF_Font *font;   // font used to render this word
+  SDL_Color color;  // word color
 };
 
 struct TextDisplayItem {
@@ -24,6 +25,7 @@ struct TextDisplayItem {
   int y;            // page coordinate
   std::string text; // UTF-8
   TTF_Font *font;   // font data
+  SDL_Color color;  // text color
 };
 
 // Font cache
@@ -73,9 +75,6 @@ private:
 
   // -------- Formatting state --------
   std::unordered_map<FontKey, TTF_Font *, FontKeyHash> font_cache_;
-  bool bold_ = false;
-  bool italic_ = false;
-  int font_size_ = 16;
 
   // -------- Layout buffers --------
   std::vector<LineItem> line_;                // current line buffer
@@ -89,16 +88,15 @@ private:
   void recurse(const Lexeme *node);
   void layoutNode(const Lexeme *node);
   void layoutElement(const Element *element);
-  void open_tag(const std::string &tag);
-  void close_tag(const std::string &tag);
-  void layoutText(const std::string &text);
+  void layoutText(const std::string &text, const Element *parent_element);
 
-  // Add a single word to the current line
-  void word(const std::string &word);
+  // Add a single word to the current line, styled according to the parent
+  // element
+  void word(const std::string &word, const Element *parent_element);
 
   // Flush the current line buffer into the display list
   void flush();
 
-  // Create or select a font matching current style state
-  TTF_Font *currentFont();
+  // Create or select a font matching current element's style state
+  TTF_Font *currentFont(const Element *element);
 };

--- a/src/layout/DisplayItem.cpp
+++ b/src/layout/DisplayItem.cpp
@@ -1,7 +1,8 @@
 #include "layout/DisplayItem.h"
 
-DrawText::DrawText(int x1, int y1, std::string text, TTF_Font *font)
-    : text_(std::move(text)), font_(font) {
+DrawText::DrawText(int x1, int y1, std::string text, TTF_Font *font,
+                   SDL_Color color)
+    : text_(std::move(text)), font_(font), color_(color) {
   left = x1;
   top = y1;
   right = x1;
@@ -12,9 +13,7 @@ void DrawText::execute(int scroll, SDL_Renderer *renderer) const {
   if (!renderer || !font_)
     return;
 
-  SDL_Color color{0, 0, 0, 255};
-
-  SDL_Surface *surface = TTF_RenderUTF8_Blended(font_, text_.c_str(), color);
+  SDL_Surface *surface = TTF_RenderUTF8_Blended(font_, text_.c_str(), color_);
   if (!surface)
     return;
 

--- a/src/layout/DisplayItem.h
+++ b/src/layout/DisplayItem.h
@@ -27,13 +27,15 @@ public:
 //   cmd->execute(scroll, renderer);
 class DrawText final : public DrawCommand {
 public:
-  DrawText(int x1, int y1, std::string text, TTF_Font *font);
+  DrawText(int x1, int y1, std::string text, TTF_Font *font,
+           SDL_Color color = {0, 0, 0, 255});
 
   void execute(int scroll, SDL_Renderer *renderer) const override;
 
 private:
   std::string text_;
   TTF_Font *font_ = nullptr;
+  SDL_Color color_;
 };
 
 // Draw a filled rectangle, used for things like code block backgrounds.

--- a/src/lexer/Element.cpp
+++ b/src/lexer/Element.cpp
@@ -36,4 +36,10 @@ void Element::appendChild(std::unique_ptr<Lexeme> child) {
   children_.push_back(std::move(child));
 }
 
+const Element::StyleMap &Element::style() const { return style_; }
+
+void Element::addStyle(const std::string &property, const std::string &value) {
+  style_[property] = value;
+}
+
 std::string Element::get_string() const { return "<" + tag_ + ">"; }

--- a/src/lexer/Element.h
+++ b/src/lexer/Element.h
@@ -8,6 +8,7 @@
 class Element : public Lexeme {
 public:
   using AttributeMap = std::unordered_map<std::string, std::string>;
+  using StyleMap = std::unordered_map<std::string, std::string>;
 
   explicit Element(std::string tag, AttributeMap attributes = {},
                    Element *parent = nullptr);
@@ -24,6 +25,10 @@ public:
   const std::vector<std::unique_ptr<Lexeme>> &children() const;
   void appendChild(std::unique_ptr<Lexeme> child);
 
+  // Computed styles for this element
+  const StyleMap &style() const;
+  void addStyle(const std::string &property, const std::string &value);
+
   // Short string form used when debugging the tree,
   // like "<p>" or "<a>".
   std::string get_string() const;
@@ -31,6 +36,7 @@ public:
 private:
   std::string tag_;
   AttributeMap attributes_;
+  StyleMap style_;
   std::vector<std::unique_ptr<Lexeme>> children_;
   Element *parent_;
 };

--- a/src/url/Url.cpp
+++ b/src/url/Url.cpp
@@ -37,3 +37,23 @@ const std::string &Url::scheme() const { return scheme_; }
 const std::string &Url::host() const { return host_; }
 const std::string &Url::path() const { return path_; }
 const std::string &Url::port() const { return port_; }
+
+Url Url::resolve(const std::string &href) const {
+  if (href.find("://") != std::string::npos) {
+    return Url(href);
+  }
+
+  if (!href.empty() && href[0] == '/') {
+    return Url(scheme_ + "://" + host_ + ":" + port_ + href);
+  }
+
+  std::string base_path = path_;
+  auto last_slash = base_path.find_last_of('/');
+  if (last_slash != std::string::npos) {
+    base_path = base_path.substr(0, last_slash + 1);
+  } else {
+    base_path = "/";
+  }
+
+  return Url(scheme_ + "://" + host_ + ":" + port_ + base_path + href);
+}

--- a/src/url/Url.h
+++ b/src/url/Url.h
@@ -10,6 +10,8 @@ public:
   const std::string &path() const;
   const std::string &port() const;
 
+  Url resolve(const std::string &href) const;
+
 private:
   std::string scheme_;
   std::string host_;


### PR DESCRIPTION
fix #11 

- Add CSS parser supporting tag and descendant selectors
- Implement cascade (specificity-based rule sorting and application)
- Add style inheritance for font-size, color, font-weight, font-style
- Refactor BlockLayout to be data-driven (reads from style_ map)
- Add StyleEngine to encapsulate the full CSS pipeline
- Fix HTMLParser attribute parsing to handle quoted values with spaces
- Add Url::resolve for relative stylesheet URL resolution
- Support background-color and text color rendering from computed styles

## Screenshots

**Before**
<img width="803" height="626" alt="image" src="https://github.com/user-attachments/assets/e4162c4b-cd9b-44f5-8c25-6dec0a359378" />

**After**
<img width="802" height="629" alt="image" src="https://github.com/user-attachments/assets/4543d01c-e8ff-4deb-8096-245bd15b1ba8" />

