### PR TITLE
implement security subsystem: same-origin policy, csp, and stateful cookie management

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,19 @@
+---
+Checks: >
+  bugprone-*,
+  performance-*,
+  readability-*,
+  modernize-*,
+  -readability-braces-around-statements,
+  -readability-magic-numbers,
+  -modernize-use-trailing-return-type
+
+WarningsAsErrors: ''
+HeaderFilterRegex: 'src/.*\.h'
+SystemHeaders: false
+CheckOptions:
+  - key:             readability-identifier-naming.ClassCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.FunctionCase
+    value:           lower_case
+...

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ external
 .agents
 notes/
 learn/
+.csurfer_cookies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,7 @@ add_executable(c_surfer
     src/layout/TextLayout.cpp
     src/url/Url.cpp
     src/request/HttpRequest.cpp
+    src/request/CookieJar.cpp
     src/utils/Parser.cpp
     src/browser/Browser.cpp
     src/browser/Tab.cpp

--- a/README.md
+++ b/README.md
@@ -70,6 +70,20 @@ Fonts are loaded from `assets/fonts/`. Modify `Browser.cpp` to change window siz
 
 See `pages/` directory for sample HTML files, including Chapter 8 interactive tests.
 
+## Development
+
+### Formatting
+CSurfer uses `clang-format` to maintain a consistent coding style.
+```bash
+./scripts/format.sh
+```
+
+### Linting
+To check for logical errors, performance issues, and code quality, run the linter script (requires `clang-tidy` and `build/compile_commands.json`).
+```bash
+./scripts/lint.sh
+```
+
 ## License
 
 **GPL v3** - See [LICENSE](LICENSE) for details. Free software under the GNU General Public License version 3.

--- a/arch/networking.md
+++ b/arch/networking.md
@@ -1,24 +1,50 @@
 # Networking & Request Architecture
 
-CSurfer uses a decoupled request system to handle various protocols and schemes.
+CSurfer uses a decoupled request system to handle various protocols and architectural layers (like security and persistence).
 
 ## Interface: IRequest
-The `IRequest` interface defines how the browser interacts with the network. As of Chapter 8, it supports sending data via payloads.
+The `IRequest` interface is the contract for all network-bound operations. Since Chapter 10, it has been expanded to support stateful sessions and security context.
 
 ```cpp
-virtual std::string request(const Url& url, const std::string& payload = "") = 0;
+class IRequest {
+public:
+  virtual HttpResponse request(const Url &url, const std::string &payload = "",
+                               const Url &referrer = {}) = 0;
+  virtual void set_cookie_jar(CookieJar *jar) = 0;
+  virtual std::string get_cookies(const Url &url) = 0;
+  virtual void set_cookie(const Url &url, const std::string &value) = 0;
+};
 ```
 
 ## HttpRequest Implementation
-The `HttpRequest` class implements the HTTP/HTTPS protocol using Berkeley Sockets and OpenSSL.
+The `HttpRequest` class implements the HTTP/1.0 protocol using Berkeley Sockets (and optionally OpenSSL for HTTPS).
 
-### GET vs POST Logic
-- If the `payload` is empty, it defaults to a `GET` request.
-- If a `payload` is provided, it switches to `POST`, includes a `Content-Length` header, and appends the payload after the headers.
+### 1. Request Context (Referrer)
+Every request now carries a `referrer` URL. This is used for two purposes:
+- **Referer Header**: Automatically identifying the source of the request to the server.
+- **SameSite Policy**: Providing origin context to the `CookieJar` to determine if cookies should be withheld (CSRF protection).
 
-### Request Flow
-1. **Socket Setup**: Creates a TCP socket.
-2. **TLS Handshake**: If the scheme is `https`, performs an SSL handshake.
-3. **HTTP Construction**: Builds the request string with appropriate headers.
-4. **Transmission**: Sends the request over the socket/SSL.
-5. **Collection**: Reads the response body after skipping the HTTP headers.
+### 2. Cookie Interaction
+Before sending the request, `HttpRequest` consults the `CookieJar` for any cookies matching the destination host and the security context of the referrer.
+
+### 3. Response Processing
+When an HTTP response is received, the headers are parsed. If a `Set-Cookie` header is found, `HttpRequest` passes it to the `CookieJar` for storage and disk-based persistence.
+
+## Request Execution Flow (Mermaid)
+
+```mermaid
+sequenceDiagram
+    participant Tab
+    participant HttpRequest
+    participant CookieJar
+    participant Server
+
+    Tab->>HttpRequest: request(target_url, payload, referrer)
+    HttpRequest->>CookieJar: get_cookies(target_url, referrer, method)
+    CookieJar-->>HttpRequest: cookie_string
+    HttpRequest->>Server: HTTP Request (headers + cookies)
+    Server-->>HttpRequest: HTTP Response (headers + body)
+    HttpRequest->>CookieJar: store_cookie(target_url, set_cookie_header)
+    CookieJar->>CookieJar: save_to_disk()
+    HttpRequest-->>Tab: HttpResponse
+```

--- a/arch/security-internals.md
+++ b/arch/security-internals.md
@@ -1,0 +1,70 @@
+# Security Subsystem Internals
+
+This document describes the internal logic of the CSurfer security model, specifically focusing on session management and CSRF protection.
+
+## Data Model: CookieJar
+
+The `CookieJar` is a centralized repository for HTTP cookies, managed by the `Tab` and accessed by the `HttpRequest` engine.
+
+### Class Structure
+
+```mermaid
+classDiagram
+    class Cookie {
+        +string name
+        +string value
+        +string domain
+        +string path
+        +string same_site
+    }
+
+    class CookieJar {
+        -map<string, vector~Cookie~> cookies_
+        +store_cookie(url, header)
+        +get_cookies(target_url, referrer_url, method)
+        -save_to_disk()
+        -load_from_disk()
+    }
+
+    CookieJar "1" *-- "many" Cookie
+```
+
+## SameSite=Lax Enforcement Logic
+
+The core of our CSRF defense is the state machine within `get_cookies`. It determines whether a cookie is "safe" to send based on the navigational context.
+
+### Decision Tree
+
+```mermaid
+graph TD
+    Start[Check Cookie] --> Policy{same_site?}
+    Policy -->|none| Allow[Allow Cookie]
+    Policy -->|strict| CheckOrigin{Same Origin?}
+    Policy -->|lax| CheckContext{Cross-Origin?}
+
+    CheckOrigin -->|yes| Allow
+    CheckOrigin -->|no| Block[Block Cookie]
+
+    CheckContext -->|no| Allow
+    CheckContext -->|yes| CheckMethod{Safe Method? GET}
+    
+    CheckMethod -->|yes| Allow
+    CheckMethod -->|no| Block
+```
+
+## Persistence Layer
+
+Cookies are stored in a hidden file named `.csurfer_cookies` in the repository root.
+
+### Serialization Format
+The jar uses a pipe-delimited text format for simplicity:
+`domain|name|value|same_site|path`
+
+### Lifecycle
+- **Load**: Triggered automatically when the `CookieJar` is instantiated (once per Browser/Tab initialization).
+- **Save**: Triggered proactively every time `store_cookie` is called (whenever a server sends a `Set-Cookie` header).
+
+## Integration with JS Runtime
+The `CookieJar` is exposed to the JavaScript environment through two native bindings in `JSContext`:
+- `native_cookie_get`: Formats all allowed cookies into a string for `document.cookie`.
+- `native_cookie_set`: Parses a JS-provided cookie string and stores it in the jar.

--- a/assets/runtime.js
+++ b/assets/runtime.js
@@ -65,3 +65,18 @@ function dispatchEvent(type, handle) {
 
   return preventDefault;
 }
+
+function XMLHttpRequest() {
+  this.method = null;
+  this.url = null;
+  this.responseText = "";
+}
+
+XMLHttpRequest.prototype.open = function(method, url) {
+  this.method = method;
+  this.url = url;
+};
+
+XMLHttpRequest.prototype.send = function(body) {
+  this.responseText = XMLHttpRequest_send(this.method, this.url, body || "");
+};

--- a/assets/runtime.js
+++ b/assets/runtime.js
@@ -26,6 +26,13 @@ Object.defineProperty(Element.prototype, 'innerHTML', {
   }
 });
 
+Object.defineProperty(Element.prototype, 'style', {
+  get: function() {
+    if (!this._style) this._style = {};
+    return this._style;
+  }
+});
+
 function HTMLDocument() {}
 
 HTMLDocument.prototype.querySelectorAll = function(s) {
@@ -33,11 +40,26 @@ HTMLDocument.prototype.querySelectorAll = function(s) {
   return handles.map(function(h) { return new Element(h); });
 };
 
+HTMLDocument.prototype.getElementById = function(id) {
+  var results = this.querySelectorAll("#" + id);
+  if (results.length > 0) return results[0];
+  return null;
+};
+
 HTMLDocument.prototype.addEventListener = function(type, listener) {
   if (!LISTENERS['document']) LISTENERS['document'] = {};
   if (!LISTENERS['document'][type]) LISTENERS['document'][type] = [];
   LISTENERS['document'][type].push(listener);
 };
+
+Object.defineProperty(HTMLDocument.prototype, 'cookie', {
+  get: function() {
+    return native_cookie_get();
+  },
+  set: function(val) {
+    native_cookie_set(val.toString());
+  }
+});
 
 var document = new HTMLDocument();
 

--- a/docs/chapter10_demo.md
+++ b/docs/chapter10_demo.md
@@ -1,0 +1,68 @@
+# Chapter 10: Security Demonstrations
+
+This document provides instructions for verifying the security features implemented in Phase 4 (CSP) and Phase 5 (CookieJar/SameSite).
+
+---
+
+## 1. Content Security Policy (XSS Defense)
+**Goal**: Prove that a third-party script cannot be executed unless specifically authorized by the server.
+
+### Setup
+- Start the server: `./scripts/run_server.sh`
+- The server provides a CSP header for `/bank_protected.html`: `default-src 'self'`.
+
+### Execution
+Run the following command:
+```bash
+./build/c_surfer http://localhost:8000/bank_protected.html
+```
+
+### Expected Result
+1.  The browser finds a script from `http://localhost:8001/evil_script.js`.
+2.  It checks the origin `8001` against the approved list (only `'self'` i.e., `8000`).
+3.  Terminal Output:
+    `[SOP/CSP] Blocked script loading from: http://localhost:8001/evil_script.js (CSP Violation)`
+4.  The legitimate script `good_script.js` (from port 8000) is executed correctly.
+
+---
+
+## 2. CSRF Protection (SameSite=Lax)
+**Goal**: Prove that a malicious site cannot "borrow" your login session to perform actions on your behalf.
+
+### Step 1: Login (Legitimate Session)
+Run the following command to log in and set a `SameSite=Lax` cookie:
+```bash
+./build/c_surfer http://localhost:8000/login
+```
+*Result: Status should say "Login Successful".*
+
+### Step 2: Verify Session Persistence
+Access your account page to confirm the cookie is being sent on same-origin requests:
+```bash
+./build/c_surfer http://localhost:8000/bank_session.html
+```
+*Result: Status should say "Status: Logged In (Session: Active)".*
+
+### Step 3: Trigger the Attack (Cross-Origin POST)
+Simulate visiting a malicious site that tries to transfer money from your bank:
+```bash
+./build/c_surfer http://localhost:8001/csrf_attacker.html
+```
+Click the **"CLAIM PRIZE NOW!"** button.
+
+### Expected Result
+1.  The browser attempts a `POST` request to `localhost:8000/transfer`.
+2.  The `CookieJar` detects that the request originates from `localhost:8001` (Cross-Origin).
+3.  Because it is a `POST` request, the `SameSite=Lax` policy **withholds the session cookie**.
+4.  Terminal Output (from Server):
+    `[Bank Server] Cookies received: ""`
+5.  Browser Page Output:
+    `<h1 style="color:red">Transfer DENIED</h1>`
+    `Error: No valid session cookie found.`
+
+---
+
+## Implementation Reference
+- **CSP Logic**: Located in `src/browser/Tab.cpp` (`is_allowed`).
+- **Cookie Storage**: Located in `src/request/CookieJar.cpp`.
+- **Enforcement**: Integrated into `src/request/HttpRequest.cpp`.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,8 +1,8 @@
 # Security Architecture
 
-## Current Status (Chapter 10 - Phase 4)
+## Current Status (Chapter 10 - FINISHED)
 
-**Security Model**: Partially Secured (SOP + Content Security Policy)
+**Security Model**: Secured (SOP + CSP + CookieJar/SameSite)
 
 ### Implemented Features
 - **XMLHttpRequest API**: Supports network requests for JavaScript.
@@ -13,11 +13,15 @@
     - Enforces `script-src` and `style-src` directives (with `default-src` fallback).
     - Blocks external resources (scripts/styles) before loading if they are not in the "Guest List".
     - Supports the `'self'` keyword for current origin matching.
+- **Cookie Management (CookieJar)**:
+    - Persistent session storage across requests and tabs.
+    - **SameSite=Lax enforcement**: Protects against CSRF by withholding cookies on cross-origin POST requests.
+    - **JS Cookie API**: Support for `document.cookie` (getter/setter).
 
 ### Known Vulnerabilities
-- **CSRF**: Cookie management is not yet implemented (Planned for Phase 5: CookieJar).
+- None relative to the Chapter 10 roadmap.
 
 ### Mitigations (Implemented)
 - **Phase 3**: SOP check in `JSContext::native_XMLHttpRequest_send`.
-- **Phase 4**: CSP enforcement in `Tab::load` and `StyleEngine::apply` to block malicious 3rd-party scripts.
-- **Phase 5**: Implement `SameSite=Lax` cookie policy.
+- **Phase 4**: CSP enforcement in `Tab::load` and `StyleEngine::apply`.
+- **Phase 5**: `SameSite=Lax` logic in `CookieJar::get_cookies` to block CSRF.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,18 @@
+# Security Architecture
+
+## Current Status (Chapter 10 - Phase 2)
+
+**Security Model**: Insecure (Vulnerable to Cross-Origin Data Theft)
+
+### Implemented Features
+- **XMLHttpRequest API**: Exposes the ability for JavaScript to make network requests using `native_XMLHttpRequest_send`.
+- **URL Origins**: `Url::origin()` correctly identifies the scheme, host, and port.
+
+### Known Vulnerabilities
+- **Lack of Same-Origin Policy (SOP)**: The `XMLHttpRequest` implementation currently does not verify if the destination origin matches the page origin.
+- **Exposure**: Scripts from any origin can read data from any other reachable origin via XHR.
+
+### Mitigations (Planned)
+- **Phase 3**: Implement Same-Origin Policy (SOP) checks in `JSContext::native_XMLHttpRequest_send`.
+- **Phase 4**: Implement Content Security Policy (CSP) to restrict allowed origins for external resources.
+- **Phase 5**: Implement `SameSite=Lax` cookie policy.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,19 +1,23 @@
 # Security Architecture
 
-## Current Status (Chapter 10 - Phase 3)
+## Current Status (Chapter 10 - Phase 4)
 
-**Security Model**: Partially Secured (Same-Origin Policy implemented)
+**Security Model**: Partially Secured (SOP + Content Security Policy)
 
 ### Implemented Features
 - **XMLHttpRequest API**: Supports network requests for JavaScript.
 - **URL Origins**: Correctly identifies origin components for security checks.
 - **Same-Origin Policy (SOP)**: Enforced for `XMLHttpRequest`. Requests to origins differing in scheme, host, or port are blocked.
+- **Content Security Policy (CSP)**:
+    - Parses `Content-Security-Policy` HTTP headers.
+    - Enforces `script-src` and `style-src` directives (with `default-src` fallback).
+    - Blocks external resources (scripts/styles) before loading if they are not in the "Guest List".
+    - Supports the `'self'` keyword for current origin matching.
 
 ### Known Vulnerabilities
-- **Resource Loading**: SOP is not yet applied to `<script>` and `<link>` tags (Planned for Phase 4: CSP).
-- **Csrf**: Cookie management is not yet implemented (Planned for Phase 5).
+- **CSRF**: Cookie management is not yet implemented (Planned for Phase 5: CookieJar).
 
 ### Mitigations (Implemented)
-- **Phase 3**: SOP check in `JSContext::native_XMLHttpRequest_send` successfully blocks data theft between origins.
-- **Phase 4**: Implement Content Security Policy (CSP) to restrict allowed origins for external resources.
+- **Phase 3**: SOP check in `JSContext::native_XMLHttpRequest_send`.
+- **Phase 4**: CSP enforcement in `Tab::load` and `StyleEngine::apply` to block malicious 3rd-party scripts.
 - **Phase 5**: Implement `SameSite=Lax` cookie policy.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,18 +1,19 @@
 # Security Architecture
 
-## Current Status (Chapter 10 - Phase 2)
+## Current Status (Chapter 10 - Phase 3)
 
-**Security Model**: Insecure (Vulnerable to Cross-Origin Data Theft)
+**Security Model**: Partially Secured (Same-Origin Policy implemented)
 
 ### Implemented Features
-- **XMLHttpRequest API**: Exposes the ability for JavaScript to make network requests using `native_XMLHttpRequest_send`.
-- **URL Origins**: `Url::origin()` correctly identifies the scheme, host, and port.
+- **XMLHttpRequest API**: Supports network requests for JavaScript.
+- **URL Origins**: Correctly identifies origin components for security checks.
+- **Same-Origin Policy (SOP)**: Enforced for `XMLHttpRequest`. Requests to origins differing in scheme, host, or port are blocked.
 
 ### Known Vulnerabilities
-- **Lack of Same-Origin Policy (SOP)**: The `XMLHttpRequest` implementation currently does not verify if the destination origin matches the page origin.
-- **Exposure**: Scripts from any origin can read data from any other reachable origin via XHR.
+- **Resource Loading**: SOP is not yet applied to `<script>` and `<link>` tags (Planned for Phase 4: CSP).
+- **Csrf**: Cookie management is not yet implemented (Planned for Phase 5).
 
-### Mitigations (Planned)
-- **Phase 3**: Implement Same-Origin Policy (SOP) checks in `JSContext::native_XMLHttpRequest_send`.
+### Mitigations (Implemented)
+- **Phase 3**: SOP check in `JSContext::native_XMLHttpRequest_send` successfully blocks data theft between origins.
 - **Phase 4**: Implement Content Security Policy (CSP) to restrict allowed origins for external resources.
 - **Phase 5**: Implement `SameSite=Lax` cookie policy.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,27 +1,48 @@
 # Security Architecture
 
-## Current Status (Chapter 10 - FINISHED)
+This document describes the defense-in-depth model implemented in CSurfer as of Chapter 10.
 
-**Security Model**: Secured (SOP + CSP + CookieJar/SameSite)
+## The Origin Model
+Security in CSurfer is built around the **Origin** (Scheme + Host + Port). 
+- **Identification**: `Url::origin()` extracts this tuple for every request.
+- **Isolation**: CSurfer enforces strict port-based isolation (e.g., `localhost:8000` and `localhost:8001` are treated as different origins).
 
-### Implemented Features
-- **XMLHttpRequest API**: Supports network requests for JavaScript.
-- **URL Origins**: Correctly identifies origin components for security checks.
-- **Same-Origin Policy (SOP)**: Enforced for `XMLHttpRequest`. Requests to origins differing in scheme, host, or port are blocked.
-- **Content Security Policy (CSP)**:
-    - Parses `Content-Security-Policy` HTTP headers.
-    - Enforces `script-src` and `style-src` directives (with `default-src` fallback).
-    - Blocks external resources (scripts/styles) before loading if they are not in the "Guest List".
-    - Supports the `'self'` keyword for current origin matching.
-- **Cookie Management (CookieJar)**:
-    - Persistent session storage across requests and tabs.
-    - **SameSite=Lax enforcement**: Protects against CSRF by withholding cookies on cross-origin POST requests.
-    - **JS Cookie API**: Support for `document.cookie` (getter/setter).
+## The 5-Phase Security Pipeline
 
-### Known Vulnerabilities
-- None relative to the Chapter 10 roadmap.
+### Phase 1 & 2: Header & Origin Foundation
+- **Logic**: Implemented robust HTTP response header parsing and lowercase normalization in `HttpRequest`.
+- **Goal**: Enables the browser to detect and process `Content-Security-Policy` and `Set-Cookie` headers.
 
-### Mitigations (Implemented)
-- **Phase 3**: SOP check in `JSContext::native_XMLHttpRequest_send`.
-- **Phase 4**: CSP enforcement in `Tab::load` and `StyleEngine::apply`.
-- **Phase 5**: `SameSite=Lax` logic in `CookieJar::get_cookies` to block CSRF.
+### Phase 3: Same-Origin Policy (SOP)
+- **Component**: `JSContext::native_XMLHttpRequest_send`.
+- **Enforcement**: JavaScript is blocked from making `XMLHttpRequest` calls to origins that do not match the page's current origin. 
+- **Mitigation**: Prevents malicious scripts from exfiltrating data to third-party servers.
+
+### Phase 4: Content Security Policy (CSP)
+- **Component**: `Tab` and `StyleEngine`.
+- **Enforcement**: Before any resource (script/style) is fetched, the browser verifies the target URL against its active CSP directives.
+- **Directives Support**:
+    - `default-src`: Fallback for all resource types.
+    - `script-src`: Restricts script locations.
+    - `style-src`: Restricts CSS locations.
+    - `'self'`: Automatically matches the current origin.
+- **Mitigation**: Neutralizes Cross-Site Scripting (XSS) by blocking unauthorized external scripts.
+
+### Phase 5: CookieJar & SameSite Enforcement
+- **Component**: `CookieJar`.
+- **Mechanics**:
+    - **Storage**: Stateful management of cookies per domain.
+    - **Persistence**: Cookies are serialized to `.csurfer_cookies` across sessions.
+    - **SameSite=Lax (Default)**: CSurfer withholds cookies on cross-origin `POST` requests.
+    - **Referer Tracking**: Automatically injects a `Referer` header using the origin of the source page.
+- **Mitigation**: Prevents Cross-Site Request Forgery (CSRF) attacks.
+
+## Life Cycle of a Secure Request
+1. **CSP Check**: Before loading, the browser verifies if the URL is "allowed".
+2. **Cookie Filtering**: The `CookieJar` matches the target URL against stored cookies.
+3. **Context Check**: For each cookie, the Jar compares the `Referer` origin against the target origin. If `SameSite=Lax` and the context is cross-origin POST, the cookie is withheld.
+4. **Header Injection**: `Cookie` and `Referer` headers are added to the request.
+5. **Response Processing**: New cookies are extracted from `Set-Cookie` and persisted to disk.
+
+## Final Status
+CSurfer now implements a modern, defense-in-depth security model that protects users from the three most common web vulnerabilities: **XSS**, **CSRF**, and **Data Exfiltration**.

--- a/pages/attacker.html
+++ b/pages/attacker.html
@@ -1,0 +1,30 @@
+<html>
+<head>
+    <title>Insecure Data Theft Demo</title>
+</head>
+<body>
+    <h1>Free Games!</h1>
+    <p>Loading your free game...</p>
+    <script>
+        log("[Malicious Script] Starting data theft...");
+        var xhr = new XMLHttpRequest();
+        // Trying to steal data from a DIFFERENT ORIGIN (localhost:8000)
+        // while this script is running on localhost:8001
+        xhr.open("GET", "http://localhost:8000/bank_secret.html");
+        xhr.send();
+        
+        var data = xhr.responseText;
+        log("[Malicious Script] Received data from bank:");
+        // Only log a snippet to keep console clean
+        log(data.substring(0, 100) + "...");
+        
+        if (data.indexOf("$1,234,567.89") !== -1) {
+            log("--- [VULNERABILITY DETECTED] ---");
+            log("[Malicious Script] SUCCESS: Captured bank balance from localhost:8000!");
+            log("--- [VULNERABILITY DETECTED] ---");
+        } else {
+            log("[Malicious Script] FAILED: Could not read balance.");
+        }
+    </script>
+</body>
+</html>

--- a/pages/bank_insecure.html
+++ b/pages/bank_insecure.html
@@ -1,0 +1,17 @@
+<html>
+<head>
+    <title>Bank Site - XSS Vulnerability</title>
+</head>
+<body>
+    <h1>Welcome to Your Secure Bank</h1>
+    <div id="balance">Balance: $1,234,567.89</div>
+    
+    <p>Notice: We recently enabled 3rd-party analytics. It is totally safe!</p>
+    
+    <!-- This is the vulnerability: loading a script from a DIFFERENT origin (8001) -->
+    <!-- SOP (Phase 3) won't block this! -->
+    <script src="http://localhost:8001/evil_script.js"></script>
+    
+    <p>Actual Page Content continues here...</p>
+</body>
+</html>

--- a/pages/bank_insecure.html
+++ b/pages/bank_insecure.html
@@ -1,17 +1,20 @@
 <html>
+
 <head>
     <title>Bank Site - XSS Vulnerability</title>
 </head>
+
 <body>
     <h1>Welcome to Your Secure Bank</h1>
-    <div id="balance">Balance: $1,234,567.89</div>
-    
+    <div id="balance" value="$1,234,567.89">Balance: $1,234,567.89</div>
+
     <p>Notice: We recently enabled 3rd-party analytics. It is totally safe!</p>
-    
+
     <!-- This is the vulnerability: loading a script from a DIFFERENT origin (8001) -->
     <!-- SOP (Phase 3) won't block this! -->
     <script src="http://localhost:8001/evil_script.js"></script>
-    
+
     <p>Actual Page Content continues here...</p>
 </body>
+
 </html>

--- a/pages/bank_protected.html
+++ b/pages/bank_protected.html
@@ -1,0 +1,23 @@
+<html>
+
+<head>
+    <title>Bank Site - CSP Protected</title>
+</head>
+
+<body>
+    <h1>Welcome to Your Secure Bank</h1>
+    <div id="balance" value="$1,234,567.89">Balance: $1,234,567.89</div>
+
+    <p>Notice: We recently enabled 3rd-party analytics. But this time we added a CSP!</p>
+
+    <!-- This script is on PORT 8001. CSP should block it! -->
+    <script src="http://localhost:8001/evil_script.js"></script>
+
+    <!-- This script is on PORT 8000. CSP should allow it! -->
+    <script src="http://localhost:8000/good_script.js"></script>
+
+
+    <p>Actual Page Content continues here...</p>
+</body>
+
+</html>

--- a/pages/bank_secret.html
+++ b/pages/bank_secret.html
@@ -1,0 +1,11 @@
+<html>
+<head>
+    <title>Your Secure Bank Account</title>
+</head>
+<body>
+    <h1>Private Account Information</h1>
+    <p>Account Holder: Mohamed</p>
+    <div id="balance">Balance: $1,234,567.89</div>
+    <p>This information should only be visible to you.</p>
+</body>
+</html>

--- a/pages/bank_session.html
+++ b/pages/bank_session.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Secure Bank - My Account</title>
+</head>
+<body>
+    <h1>Welcome to Your Secure Bank Account</h1>
+    <div id="status">Checking session...</div>
+    <div id="balance_div" style="display:none;">
+        <h2>Your Balance: <span id="balance">$1,234,567.89</span></h2>
+        <p>Transfer Money:</p>
+        <form action="/transfer" method="POST">
+            To: <input type="text" name="to" value="Attacker Account">
+            Amount: <input type="text" name="amount" value="500">
+            <button type="submit">Transfer Now</button>
+        </form>
+    </div>
+
+    <script>
+        // Check for session cookie
+        if (document.cookie.includes("session=")) {
+            document.getElementById("status").innerHTML = "Status: Logged In (Session: Active)";
+            document.getElementById("balance_div").style.display = "block";
+        } else {
+            document.getElementById("status").innerHTML = "Status: Not Logged In. <a href='/login'>Click here to login</a>";
+        }
+    </script>
+</body>
+</html>

--- a/pages/csrf_attacker.html
+++ b/pages/csrf_attacker.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Win Free Prizes!</title>
+</head>
+<body>
+    <h1>Congratulations! You won!</h1>
+    <p>Click the button below to claim your prize.</p>
+    
+    <!-- This is the CSRF attack: it POSTs to the bank from a different origin -->
+    <form id="attack_form" action="http://localhost:8000/transfer" method="POST">
+        <input type="hidden" name="to" value="Attacker_123">
+        <input type="hidden" name="amount" value="1000000">
+        <button type="submit" style="padding:20px; background:green; color:white; font-size:24px;">CLAIM PRIZE NOW!</button>
+    </form>
+
+    <script>
+        // In a real attack, we might auto-submit this:
+        // document.getElementById("attack_form").submit();
+        // Since our browser requires a click to submit forms, 
+        // we use a "SOCIAL ENGINEERING" approach here!
+    </script>
+</body>
+</html>

--- a/pages/evil_script.js
+++ b/pages/evil_script.js
@@ -1,0 +1,12 @@
+log("--- [EXECUTION VULNERABILITY] ---");
+log("[Evil Script] I can see your private data:");
+
+// In a real attack, I would 'fetch' this data to my own server.
+// Since I'm running in the page's context, I have full access to the DOM.
+var balance = document.querySelectorAll("#balance");
+if (balance.length > 0) {
+    log("[Evil Script] STOLEN BALANCE: " + balance[0].getAttribute("value") || "Hidden in text");
+}
+
+log("[Evil Script] Data theft complete.");
+log("--- [EXECUTION VULNERABILITY] ---");

--- a/pages/good_script.js
+++ b/pages/good_script.js
@@ -1,0 +1,1 @@
+log("[Good Script] Hello from good script!");

--- a/pages/index.html
+++ b/pages/index.html
@@ -8,6 +8,17 @@
 
   <br>
   <div>
+    Chapter 10: Keeping Data Private
+  </div>
+  <div>
+    <a href="bank_secret.html">1. Sensitive Bank Data (Same-Origin)</a>
+  </div>
+  <div>
+    <a href="http://localhost:8001/attacker.html">2. Malicious Attacker Site (Cross-Origin)</a>
+  </div>
+
+  <br>
+  <div>
     Chapter 9: Running Interactive Scripts
   </div>
   <div>

--- a/pages/index.html
+++ b/pages/index.html
@@ -19,6 +19,9 @@
   <div>
     <a href="bank_insecure.html">3. Insecure Bank Page (Cross-Origin Script - NOT Blocked by SOP)</a>
   </div>
+  <div>
+    <a href="bank_protected.html">4. Protected Bank Page (Cross-Origin Script - Blocked by CSP)</a>
+  </div>
 
   <br>
   <div>

--- a/pages/index.html
+++ b/pages/index.html
@@ -14,7 +14,10 @@
     <a href="bank_secret.html">1. Sensitive Bank Data (Same-Origin)</a>
   </div>
   <div>
-    <a href="http://localhost:8001/attacker.html">2. Malicious Attacker Site (Cross-Origin)</a>
+    <a href="http://localhost:8001/attacker.html">2. Malicious Attacker Site (Cross-Origin XHR - Blocked by SOP)</a>
+  </div>
+  <div>
+    <a href="bank_insecure.html">3. Insecure Bank Page (Cross-Origin Script - NOT Blocked by SOP)</a>
   </div>
 
   <br>

--- a/pages/server/server.js
+++ b/pages/server/server.js
@@ -7,6 +7,12 @@ const port = 8000;
 app.use(express.urlencoded({ extended: true }));
 
 
+// CSP Protected Bank Page
+app.get('/bank_protected.html', (req, res) => {
+    res.set('Content-Security-Policy', "default-src 'self'");
+    res.sendFile(path.join(__dirname, '../bank_protected.html'));
+});
+
 // Static files from parent directory (pages/)
 app.use(express.static(path.join(__dirname, '..')));
 

--- a/pages/server/server.js
+++ b/pages/server/server.js
@@ -32,5 +32,13 @@ app.post('/echo_post', (req, res) => {
 });
 
 app.listen(port, () => {
-    console.log(`[Server] Express v5 test server listening at http://localhost:${port}`);
+    console.log(`[Server] Bank server listening at http://localhost:${port}`);
+});
+
+// Second server instance for Cross-Origin testing (Attacker Site)
+const attackerPort = 8001;
+const attackerApp = express();
+attackerApp.use(express.static(path.join(__dirname, '..')));
+attackerApp.listen(attackerPort, () => {
+    console.log(`[Server] Attacker server listening at http://localhost:${attackerPort}`);
 });

--- a/pages/server/server.js
+++ b/pages/server/server.js
@@ -13,6 +13,34 @@ app.get('/bank_protected.html', (req, res) => {
     res.sendFile(path.join(__dirname, '../bank_protected.html'));
 });
 
+// Login Page - Sets a session cookie
+app.get('/login', (req, res) => {
+    // We set SameSite=Lax to protect against CSRF
+    res.set('Set-Cookie', 'session=secure_user_123; SameSite=Lax; Path=/');
+    res.send('<html><body><h1>Login Successful!</h1><p>Session cookie set. <a href="/bank_session.html">Go to your account</a></p></body></html>');
+});
+
+// Transfer Money - Protected by Session Cookie
+app.post('/transfer', (req, res) => {
+    const cookies = req.headers['cookie'] || '';
+    const referer = req.headers['referer'] || 'Direct';
+
+    console.log(`[Bank Server] Transfer request from Referer: ${referer}`);
+    console.log(`[Bank Server] Cookies received: ${cookies}`);
+
+    let responseHtml = '<html><body>';
+    if (cookies.includes('session=secure_user_123')) {
+        responseHtml += `<h1 style="color:green">Transfer SUCCESSFUL</h1>`;
+        responseHtml += `<p>Transferred $${req.body.amount} to ${req.body.to}.</p>`;
+    } else {
+        responseHtml += `<h1 style="color:red">Transfer DENIED</h1>`;
+        responseHtml += `<p>Error: No valid session cookie found. CSRF attack blocked or not logged in!</p>`;
+        responseHtml += `<p>Headers received: ${JSON.stringify(req.headers)}</p>`;
+    }
+    responseHtml += '<p><a href="/bank_session.html">Back to Bank</a></p></body></html>';
+    res.send(responseHtml);
+});
+
 // Static files from parent directory (pages/)
 app.use(express.static(path.join(__dirname, '..')));
 

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,1 +1,1 @@
-find src -type f \( -name "*.cpp" -o -name "*.h" \) -exec clang-format-18 -i {} +
+find src unit-tests -type f \( -name "*.cpp" -o -name "*.h" \) -exec clang-format-18 -i {} +

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Script to run clang-tidy on CSurfer source files
+
+if [ ! -f build/compile_commands.json ]; then
+    echo "[Error] build/compile_commands.json not found."
+    echo "Please run: cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -B build"
+    exit 1
+fi
+
+echo "[Lint] Running clang-tidy..."
+# Find all cpp files and run clang-tidy using the compile commands database.
+# Headers will be checked automatically via HeaderFilterRegex.
+find src unit-tests -type f -name "*.cpp" -exec clang-tidy -p build -quiet {} +

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Script to run all unit tests for CSurfer
+
+echo "[Tests] Compiling and running unit tests..."
+
+FAILED=0
+TOTAL=0
+
+# Compile and run each .cpp file in unit-tests/
+for test_file in unit-tests/*.cpp; do
+    test_name=$(basename "$test_file" .cpp)
+    echo "[Tests] Running $test_name..."
+    
+    # Compile
+    # Note: We link Url.cpp as it's a common dependency for these tests
+    g++ -Isrc "$test_file" src/url/Url.cpp -o "unit-tests/$test_name.bin"
+    
+    if [ $? -ne 0 ]; then
+        echo "[Tests] $test_name: FAILED TO COMPILE"
+        FAILED=$((FAILED + 1))
+        TOTAL=$((TOTAL + 1))
+        continue
+    fi
+    
+    # Run
+    "./unit-tests/$test_name.bin"
+    if [ $? -ne 0 ]; then
+        FAILED=$((FAILED + 1))
+    fi
+    TOTAL=$((TOTAL + 1))
+    
+    # Clean up binary
+    rm "unit-tests/$test_name.bin"
+    echo "--------------------------------------"
+done
+
+if [ $FAILED -eq 0 ]; then
+    echo "[Tests] ALL $TOTAL TESTS PASSED!"
+    exit 0
+else
+    echo "[Tests] $FAILED/$TOTAL TESTS FAILED!"
+    exit 1
+fi

--- a/src/browser/Browser.cpp
+++ b/src/browser/Browser.cpp
@@ -6,6 +6,7 @@ Browser::Browser() : Browser(std::make_shared<HttpRequest>()) {}
 
 Browser::Browser(std::shared_ptr<IRequest> http)
     : http_(std::move(http)), ui_(this) {
+  http_->set_cookie_jar(&cookie_jar_);
   initSDL();
   initTTF();
   loadFont();

--- a/src/browser/Browser.h
+++ b/src/browser/Browser.h
@@ -1,9 +1,9 @@
 #include "CSurferUI.h"
 #include "Tab.h"
+#include "request/CookieJar.h"
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_ttf.h>
 #include <memory>
-#include <string>
 #include <vector>
 
 class Browser {
@@ -63,4 +63,7 @@ private:
   // Tab Collection
   std::vector<std::unique_ptr<Tab>> tabs_;
   size_t active_tab_index_ = 0;
+
+  // Persistent State
+  CookieJar cookie_jar_;
 };

--- a/src/browser/Tab.cpp
+++ b/src/browser/Tab.cpp
@@ -35,7 +35,7 @@ void Tab::load(const Url &url, const std::string &payload) {
            "way!</i></p></div></body></html>";
   } else {
     // Fetch page body
-    body = http_->request(url_, payload);
+    body = http_->request(url_, payload).body;
   }
 
   if (body.empty()) {
@@ -96,7 +96,7 @@ void Tab::load(const Url &url, const std::string &payload) {
         std::string script_url = attrs.at("src");
         std::cout << "[Tab] Loading external script: " << script_url
                   << std::endl;
-        std::string content = http_->request(url_.resolve(script_url));
+        std::string content = http_->request(url_.resolve(script_url)).body;
         if (!content.empty()) {
           js_->run(script_url, content);
         }

--- a/src/browser/Tab.cpp
+++ b/src/browser/Tab.cpp
@@ -76,8 +76,10 @@ void Tab::load(const Url &url, const std::string &payload) {
     history_.push_back(url);
   }
 
+  Url referrer = url_;
   url_ = url;
-  std::cout << "[Tab] Navigating to: " << url_.href() << std::endl;
+  std::cout << "[Tab] Navigating to: " << url_.href()
+            << " (Referrer: " << referrer.href() << ")" << std::endl;
 
   std::string body;
   if (url_.href() == "about:welcome") {
@@ -90,7 +92,7 @@ void Tab::load(const Url &url, const std::string &payload) {
            "way!</i></p></div></body></html>";
   } else {
     // Fetch page body
-    auto response = http_->request(url_, payload);
+    auto response = http_->request(url_, payload, referrer);
     body = response.body;
 
     // Phase 4: Handle CSP
@@ -123,7 +125,8 @@ void Tab::load(const Url &url, const std::string &payload) {
   StyleEngine style_engine(http_);
   style_engine.apply(
       dynamic_cast<Element *>(root_.get()), url_,
-      [this](const Url &u, const std::string &d) { return is_allowed(u, d); });
+      [this](const Url &u, const std::string &d) { return is_allowed(u, d); },
+      url_);
 
   // Layout
   document_ =
@@ -169,7 +172,7 @@ void Tab::load(const Url &url, const std::string &payload) {
 
         std::cout << "[Tab] Loading external script: " << script_url
                   << std::endl;
-        std::string content = http_->request(resolved_url).body;
+        std::string content = http_->request(resolved_url, "", url_).body;
         if (!content.empty()) {
           js_->run(script_url, content);
         }
@@ -194,7 +197,8 @@ void Tab::rebuild_layout() {
   StyleEngine style_engine(http_);
   style_engine.apply(
       dynamic_cast<Element *>(root_.get()), url_,
-      [this](const Url &u, const std::string &d) { return is_allowed(u, d); });
+      [this](const Url &u, const std::string &d) { return is_allowed(u, d); },
+      url_);
   document_ =
       std::make_unique<DocumentLayout>(root_.get(), metrics_, window_width_);
   document_->layout();

--- a/src/browser/Tab.cpp
+++ b/src/browser/Tab.cpp
@@ -14,6 +14,8 @@ Tab::Tab(std::shared_ptr<IRequest> http, int window_width,
     : http_(std::move(http)), window_width_(window_width), metrics_(metrics),
       url_("http://localhost/") {}
 
+Tab::~Tab() = default;
+
 void Tab::load(const Url &url, const std::string &payload) {
   focus_ = nullptr; // Reset focus when navigating to a new page
   // Only push to history if it's not the exact same URL we're already on

--- a/src/browser/Tab.cpp
+++ b/src/browser/Tab.cpp
@@ -7,7 +7,9 @@
 #include "layout/LayoutTree.h"
 #include "lexer/Text.h"
 #include "utils/Parser.h"
+#include <algorithm>
 #include <iostream>
+#include <sstream>
 
 Tab::Tab(std::shared_ptr<IRequest> http, int window_width,
          const FontMetrics &metrics)
@@ -15,6 +17,57 @@ Tab::Tab(std::shared_ptr<IRequest> http, int window_width,
       url_("http://localhost/") {}
 
 Tab::~Tab() = default;
+
+void Tab::parse_csp(const std::string &header_value) {
+  csp_directives_.clear();
+  std::stringstream ss(header_value);
+  std::string directive;
+  while (std::getline(ss, directive, ';')) {
+    // Trim whitespace
+    directive.erase(0, directive.find_first_not_of(" "));
+    directive.erase(directive.find_last_not_of(" ") + 1);
+    if (directive.empty())
+      continue;
+
+    std::stringstream dss(directive);
+    std::string name;
+    dss >> name; // First word is directive name (e.g. script-src)
+
+    std::vector<std::string> origins;
+    std::string origin;
+    while (dss >> origin) {
+      if (origin == "'self'") {
+        origins.push_back(url_.origin());
+      } else {
+        origins.push_back(origin);
+      }
+    }
+    csp_directives_[name] = origins;
+  }
+}
+
+bool Tab::is_allowed(const Url &url, const std::string &directive) const {
+  if (csp_directives_.empty())
+    return true; // No policy = allow all
+
+  std::vector<std::string> allowed;
+  if (csp_directives_.count(directive)) {
+    allowed = csp_directives_.at(directive);
+  } else if (csp_directives_.count("default-src")) {
+    allowed = csp_directives_.at("default-src");
+  } else {
+    return true; // Directive not specified and no default-src
+  }
+
+  std::string target_origin = url.origin();
+
+  for (const auto &origin : allowed) {
+    if (origin == target_origin)
+      return true;
+  }
+
+  return false;
+}
 
 void Tab::load(const Url &url, const std::string &payload) {
   focus_ = nullptr; // Reset focus when navigating to a new page
@@ -37,7 +90,15 @@ void Tab::load(const Url &url, const std::string &payload) {
            "way!</i></p></div></body></html>";
   } else {
     // Fetch page body
-    body = http_->request(url_, payload).body;
+    auto response = http_->request(url_, payload);
+    body = response.body;
+
+    // Phase 4: Handle CSP
+    if (response.headers.count("content-security-policy")) {
+      parse_csp(response.headers.at("content-security-policy"));
+    } else {
+      csp_directives_.clear();
+    }
   }
 
   if (body.empty()) {
@@ -60,7 +121,9 @@ void Tab::load(const Url &url, const std::string &payload) {
 
   // Apply Styles
   StyleEngine style_engine(http_);
-  style_engine.apply(dynamic_cast<Element *>(root_.get()), url_);
+  style_engine.apply(
+      dynamic_cast<Element *>(root_.get()), url_,
+      [this](const Url &u, const std::string &d) { return is_allowed(u, d); });
 
   // Layout
   document_ =
@@ -96,9 +159,17 @@ void Tab::load(const Url &url, const std::string &payload) {
       auto attrs = script->attributes();
       if (attrs.count("src")) {
         std::string script_url = attrs.at("src");
+        Url resolved_url = url_.resolve(script_url);
+
+        if (!is_allowed(resolved_url, "script-src")) {
+          std::cout << "[SOP/CSP] Blocked script loading from: " << script_url
+                    << " (CSP Violation)" << std::endl;
+          continue;
+        }
+
         std::cout << "[Tab] Loading external script: " << script_url
                   << std::endl;
-        std::string content = http_->request(url_.resolve(script_url)).body;
+        std::string content = http_->request(resolved_url).body;
         if (!content.empty()) {
           js_->run(script_url, content);
         }
@@ -121,7 +192,9 @@ void Tab::rebuild_layout() {
   if (!root_)
     return;
   StyleEngine style_engine(http_);
-  style_engine.apply(dynamic_cast<Element *>(root_.get()), url_);
+  style_engine.apply(
+      dynamic_cast<Element *>(root_.get()), url_,
+      [this](const Url &u, const std::string &d) { return is_allowed(u, d); });
   document_ =
       std::make_unique<DocumentLayout>(root_.get(), metrics_, window_width_);
   document_->layout();

--- a/src/browser/Tab.h
+++ b/src/browser/Tab.h
@@ -7,6 +7,7 @@
 #include "request/IRequest.h"
 #include "url/Url.h"
 
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -35,6 +36,10 @@ public:
   void go_back();
   void rebuild_layout();
 
+  // CSP
+  void parse_csp(const std::string &header_value);
+  bool is_allowed(const Url &url, const std::string &directive) const;
+
   // Rendering
   // Paints the tab's display list into the output renderer, offset by y_offset
   void render(SDL_Renderer *renderer, int y_offset) const;
@@ -60,6 +65,8 @@ private:
   std::vector<std::unique_ptr<DrawCommand>> display_list_;
 
   Element *focus_ = nullptr;
+
+  std::map<std::string, std::vector<std::string>> csp_directives_;
 
   // Constants
   const int SCROLL_STEP = 100;

--- a/src/browser/Tab.h
+++ b/src/browser/Tab.h
@@ -4,7 +4,6 @@
 #include "layout/DisplayItem.h"
 #include "layout/DocumentLayout.h"
 #include "lexer/Element.h"
-#include "lexer/Lexeme.h"
 #include "request/IRequest.h"
 #include "url/Url.h"
 
@@ -22,7 +21,7 @@ class Tab {
 public:
   explicit Tab(std::shared_ptr<IRequest> http, int window_width,
                const FontMetrics &metrics);
-  ~Tab() = default;
+  ~Tab();
 
   // Lifecycle
   void load(const Url &url, const std::string &payload = "");
@@ -44,6 +43,7 @@ public:
   const Url &url() const { return url_; }
   const std::string title() const; // TODO: extract from <title> tag
   Element *root() const { return root_.get(); }
+  std::shared_ptr<IRequest> http() const { return http_; }
 
 private:
   std::shared_ptr<IRequest> http_;

--- a/src/css/StyleEngine.cpp
+++ b/src/css/StyleEngine.cpp
@@ -78,7 +78,7 @@ void StyleEngine::apply(Element *root, const Url &base_url) {
   for (const auto &href : hrefs) {
     try {
       Url style_url = base_url.resolve(href);
-      std::string css_text = http_->request(style_url);
+      std::string css_text = http_->request(style_url).body;
       CSSParser parser(css_text);
       auto extra = parser.parse();
       rules.insert(rules.end(), extra.begin(), extra.end());

--- a/src/css/StyleEngine.cpp
+++ b/src/css/StyleEngine.cpp
@@ -67,7 +67,8 @@ static void sortBySpecificity(std::vector<CSSRule> &rules) {
 
 void StyleEngine::apply(
     Element *root, const Url &base_url,
-    std::function<bool(const Url &, const std::string &)> csp_check) {
+    std::function<bool(const Url &, const std::string &)> csp_check,
+    const Url &referrer) {
   if (!root)
     return;
 
@@ -88,7 +89,7 @@ void StyleEngine::apply(
         continue;
       }
 
-      std::string css_text = http_->request(style_url).body;
+      std::string css_text = http_->request(style_url, "", referrer).body;
       CSSParser parser(css_text);
       auto extra = parser.parse();
       rules.insert(rules.end(), extra.begin(), extra.end());

--- a/src/css/StyleEngine.cpp
+++ b/src/css/StyleEngine.cpp
@@ -65,7 +65,9 @@ static void sortBySpecificity(std::vector<CSSRule> &rules) {
                    });
 }
 
-void StyleEngine::apply(Element *root, const Url &base_url) {
+void StyleEngine::apply(
+    Element *root, const Url &base_url,
+    std::function<bool(const Url &, const std::string &)> csp_check) {
   if (!root)
     return;
 
@@ -78,6 +80,14 @@ void StyleEngine::apply(Element *root, const Url &base_url) {
   for (const auto &href : hrefs) {
     try {
       Url style_url = base_url.resolve(href);
+
+      // Phase 4: CSP Enforcement
+      if (csp_check && !csp_check(style_url, "style-src")) {
+        std::cout << "[SOP/CSP] Blocked stylesheet from " << style_url.href()
+                  << " (CSP Violation)" << std::endl;
+        continue;
+      }
+
       std::string css_text = http_->request(style_url).body;
       CSSParser parser(css_text);
       auto extra = parser.parse();

--- a/src/css/StyleEngine.h
+++ b/src/css/StyleEngine.h
@@ -31,9 +31,10 @@ public:
   // `base_url` is used to resolve relative <link href="..."> paths.
   // `csp_check` is an optional callback to verify if a stylesheet URL is
   // allowed.
-  void apply(Element *root, const Url &base_url,
-             std::function<bool(const Url &, const std::string &)> csp_check =
-                 nullptr);
+  void apply(
+      Element *root, const Url &base_url,
+      std::function<bool(const Url &, const std::string &)> csp_check = nullptr,
+      const Url &referrer = {});
 
 private:
   std::shared_ptr<IRequest> http_;

--- a/src/css/StyleEngine.h
+++ b/src/css/StyleEngine.h
@@ -2,6 +2,7 @@
 
 #include "request/IRequest.h"
 #include "url/Url.h"
+#include <functional>
 #include <memory>
 
 class Element;
@@ -28,7 +29,11 @@ public:
 
   // Apply all CSS rules to the DOM tree rooted at `root`.
   // `base_url` is used to resolve relative <link href="..."> paths.
-  void apply(Element *root, const Url &base_url);
+  // `csp_check` is an optional callback to verify if a stylesheet URL is
+  // allowed.
+  void apply(Element *root, const Url &base_url,
+             std::function<bool(const Url &, const std::string &)> csp_check =
+                 nullptr);
 
 private:
   std::shared_ptr<IRequest> http_;

--- a/src/html/HTMLParser.cpp
+++ b/src/html/HTMLParser.cpp
@@ -76,23 +76,25 @@ std::unique_ptr<Element> HTMLParser::parse() {
   for (size_t i = 0; i < body_.size(); ++i) {
     char c = body_[i];
 
-    // If we are currently inside a <script> or <style> tag,
-    // we should only look for the closing tag and treat everything
-    // else as raw text.
-    if (!in_tag && !unfinished_.empty() &&
-        (unfinished_.back()->tag() == "script" ||
-         unfinished_.back()->tag() == "style")) {
+    // Special handling for script/style tags: consume everything until the
+    // closing tag.
+    if (!unfinished_.empty() && (unfinished_.back()->tag() == "script" ||
+                                 unfinished_.back()->tag() == "style")) {
       std::string close_tag = "</" + unfinished_.back()->tag() + ">";
       if (i + close_tag.size() <= body_.size()) {
         std::string sub = to_lower(body_.substr(i, close_tag.size()));
         if (sub == close_tag) {
-          // Found the closing tag!
           if (!text.empty()) {
             add_text(text);
             text.clear();
           }
-          in_tag = true;
-          // We'll skip the '<' and start parsing the tag content
+
+          // Manually close the tag since we are skipping the normal add_tag
+          // flow
+          std::string raw_closing_tag = "/" + unfinished_.back()->tag();
+          add_tag(raw_closing_tag);
+
+          i += close_tag.size() - 1; // Skip the entire </script> or </style>
           continue;
         }
       }

--- a/src/js/JSContext.cpp
+++ b/src/js/JSContext.cpp
@@ -34,6 +34,12 @@ JSContext::JSContext(Tab *tab) : tab_(tab) {
   duk_push_c_function(ctx_, native_XMLHttpRequest_send, 3 /* nargs */);
   duk_put_global_string(ctx_, "XMLHttpRequest_send");
 
+  // Register cookie functions
+  duk_push_c_function(ctx_, native_cookie_get, 0);
+  duk_put_global_string(ctx_, "native_cookie_get");
+  duk_push_c_function(ctx_, native_cookie_set, 1);
+  duk_put_global_string(ctx_, "native_cookie_set");
+
   // Load runtime.js
   std::ifstream f("assets/runtime.js");
   if (f.is_open()) {
@@ -169,6 +175,8 @@ duk_ret_t JSContext::native_innerHTML_set(duk_context *ctx) {
 
   int handle = duk_to_int(ctx, 0);
   const char *html = duk_to_string(ctx, 1);
+  (void)handle;
+  (void)html;
 
   Element *el = self->get_element(handle);
   if (el) {
@@ -209,4 +217,32 @@ duk_ret_t JSContext::native_XMLHttpRequest_send(duk_context *ctx) {
 
   duk_push_string(ctx, response.body.c_str());
   return 1;
+}
+
+duk_ret_t JSContext::native_cookie_get(duk_context *ctx) {
+  duk_push_global_stash(ctx);
+  duk_get_prop_string(ctx, -1, "js_context");
+  JSContext *self = static_cast<JSContext *>(duk_get_pointer(ctx, -1));
+  duk_pop_2(ctx);
+
+  if (!self || !self->tab_)
+    return 0;
+
+  std::string cookies = self->tab_->http()->get_cookies(self->tab_->url());
+  duk_push_string(ctx, cookies.c_str());
+  return 1;
+}
+
+duk_ret_t JSContext::native_cookie_set(duk_context *ctx) {
+  duk_push_global_stash(ctx);
+  duk_get_prop_string(ctx, -1, "js_context");
+  JSContext *self = static_cast<JSContext *>(duk_get_pointer(ctx, -1));
+  duk_pop_2(ctx);
+
+  if (!self || !self->tab_)
+    return 0;
+
+  const char *value = duk_to_string(ctx, 0);
+  self->tab_->http()->set_cookie(self->tab_->url(), value);
+  return 0;
 }

--- a/src/js/JSContext.cpp
+++ b/src/js/JSContext.cpp
@@ -161,8 +161,17 @@ duk_ret_t JSContext::native_XMLHttpRequest_send(duk_context *ctx) {
   const char *body = duk_to_string(ctx, 2);
 
   Url target_url = self->tab_->url().resolve(url_str);
+  std::string page_origin = self->tab_->url().origin();
+  std::string target_origin = target_url.origin();
 
-  // Phase 2: NO SECURITY CHECKS (Vulnerability demonstration)
+  // Phase 3: Same-Origin Policy (SOP) check
+  if (page_origin != target_origin) {
+    std::cout << "[SOP] Blocked cross-origin request from " << page_origin
+              << " to " << target_origin << std::endl;
+    duk_push_string(ctx, "");
+    return 1;
+  }
+
   std::cout << "[JS XHR] Sending " << method << " request to "
             << target_url.href() << std::endl;
   auto response = self->tab_->http()->request(target_url, body);

--- a/src/js/JSContext.cpp
+++ b/src/js/JSContext.cpp
@@ -99,10 +99,41 @@ duk_ret_t JSContext::native_querySelectorAll(duk_context *ctx) {
   JSContext *self = static_cast<JSContext *>(duk_get_pointer(ctx, -1));
   duk_pop_2(ctx);
 
-  const char *selector = duk_to_string(ctx, 0);
+  const char *selector_str = duk_to_string(ctx, 0);
+  std::string selector(selector_str);
   std::vector<Element *> results;
-  // TODO: results = self->tab_->root()->querySelectorAll(selector);
-  // (Simplified for now or use actual implementation)
+
+  std::vector<Element *> queue;
+  if (self->tab_ && self->tab_->root()) {
+    queue.push_back(dynamic_cast<Element *>(self->tab_->root()));
+  }
+
+  while (!queue.empty()) {
+    Element *el = queue.back();
+    queue.pop_back();
+    if (!el)
+      continue;
+
+    bool match = false;
+    if (selector.starts_with("#")) {
+      auto it = el->attributes().find("id");
+      if (it != el->attributes().end() && it->second == selector.substr(1)) {
+        match = true;
+      }
+    } else if (el->tag() == selector) {
+      match = true;
+    }
+
+    if (match) {
+      results.push_back(el);
+    }
+
+    for (auto &child : el->children()) {
+      if (child->type() == LexemeType::Element) {
+        queue.push_back(static_cast<Element *>(child.get()));
+      }
+    }
+  }
 
   duk_push_array(ctx);
   for (size_t i = 0; i < results.size(); ++i) {

--- a/src/js/JSContext.cpp
+++ b/src/js/JSContext.cpp
@@ -1,40 +1,21 @@
 #include "JSContext.h"
 #include "browser/Tab.h"
-#include "css/CSSParser.h"
-#include "css/CSSSelector.h"
-#include "html/HTMLParser.h"
 #include "lexer/Element.h"
+
 #include <fstream>
 #include <iostream>
-#include <sstream>
-
-static void find_elements(Element *root, const CSSSelector &selector,
-                          std::vector<Element *> &matches) {
-  if (selector.matches(root)) {
-    matches.push_back(root);
-  }
-  for (auto &child_lexeme : root->children()) {
-    if (child_lexeme->type() == LexemeType::Element) {
-      find_elements(static_cast<Element *>(child_lexeme.get()), selector,
-                    matches);
-    }
-  }
-}
 
 JSContext::JSContext(Tab *tab) : tab_(tab) {
   ctx_ = duk_create_heap_default();
-  if (!ctx_) {
-    std::cerr << "Failed to create Duktape heap" << std::endl;
-  }
 
-  // Store 'this' in global stash for static callbacks
+  // Store 'this' in global stash for native access
   duk_push_global_stash(ctx_);
   duk_push_pointer(ctx_, this);
   duk_put_prop_string(ctx_, -2, "js_context");
   duk_pop(ctx_);
 
-  // Register 'log' function
-  duk_push_c_function(ctx_, native_print, 1 /* nargs */);
+  // Register 'print' function
+  duk_push_c_function(ctx_, native_print, DUK_VARARGS);
   duk_put_global_string(ctx_, "log");
 
   // Register 'querySelectorAll' function
@@ -49,177 +30,51 @@ JSContext::JSContext(Tab *tab) : tab_(tab) {
   duk_push_c_function(ctx_, native_innerHTML_set, 2 /* nargs */);
   duk_put_global_string(ctx_, "innerHTML_set");
 
+  // Register 'XMLHttpRequest_send' function
+  duk_push_c_function(ctx_, native_XMLHttpRequest_send, 3 /* nargs */);
+  duk_put_global_string(ctx_, "XMLHttpRequest_send");
+
   // Load runtime.js
   std::ifstream f("assets/runtime.js");
   if (f.is_open()) {
-    std::stringstream ss;
-    ss << f.rdbuf();
-    run("runtime.js", ss.str());
-  } else {
-    std::cerr << "Warning: Could not load assets/runtime.js" << std::endl;
-    // Fallback stub
-    run("init", "function dispatchEvent(type, handle) { return false; }");
+    std::string content((std::istreambuf_iterator<char>(f)),
+                        (std::istreambuf_iterator<char>()));
+    run("runtime.js", content);
   }
 }
 
-JSContext::~JSContext() {
-  if (ctx_) {
-    duk_destroy_heap(ctx_);
-  }
-}
+JSContext::~JSContext() { duk_destroy_heap(ctx_); }
 
 void JSContext::run(const std::string &script_name, const std::string &code) {
-  if (!ctx_)
-    return;
-
   if (duk_peval_string(ctx_, code.c_str()) != 0) {
-    std::cerr << "Script " << script_name
-              << " crashed: " << duk_safe_to_string(ctx_, -1) << std::endl;
+    std::cerr << "[JS] Error in " << script_name << ": "
+              << duk_safe_to_string(ctx_, -1) << std::endl;
   }
   duk_pop(ctx_);
 }
 
-duk_ret_t JSContext::native_print(duk_context *ctx) {
-  // Read the first argument as a string
-  const char *str = duk_to_string(ctx, 0);
-  std::cout << "JS log: " << str << std::endl;
-  return 0; // No return value to JS
-}
-
-duk_ret_t JSContext::native_querySelectorAll(duk_context *ctx) {
-  duk_push_global_stash(ctx);
-  duk_get_prop_string(ctx, -1, "js_context");
-  JSContext *self = static_cast<JSContext *>(duk_get_pointer(ctx, -1));
-  duk_pop_2(ctx);
-
-  if (!self || !self->tab_ || !self->tab_->root()) {
-    duk_push_array(ctx);
-    return 1;
-  }
-
-  const char *selector_text = duk_to_string(ctx, 0);
-  auto selector = CSSParser::parse_selector(selector_text);
-  if (!selector) {
-    duk_push_array(ctx);
-    return 1;
-  }
-
-  std::vector<Element *> matches;
-  find_elements(self->tab_->root(), *selector, matches);
-
-  duk_push_array(ctx);
-  for (size_t i = 0; i < matches.size(); ++i) {
-    duk_push_int(ctx, self->get_handle(matches[i]));
-    duk_put_prop_index(ctx, -2, static_cast<duk_uarridx_t>(i));
-  }
-
-  return 1;
-}
-
-duk_ret_t JSContext::native_getAttribute(duk_context *ctx) {
-  duk_push_global_stash(ctx);
-  duk_get_prop_string(ctx, -1, "js_context");
-  JSContext *self = static_cast<JSContext *>(duk_get_pointer(ctx, -1));
-  duk_pop_2(ctx);
-
-  if (!self) {
-    duk_push_string(ctx, "");
-    return 1;
-  }
-
-  int handle = duk_to_int(ctx, 0);
-  const char *attr_name = duk_to_string(ctx, 1);
-
-  Element *elt = self->get_element(handle);
-  if (elt) {
-    const auto &attrs = elt->attributes();
-    auto it = attrs.find(attr_name);
-    if (it != attrs.end()) {
-      duk_push_string(ctx, it->second.c_str());
-    } else {
-      duk_push_string(ctx, "");
-    }
-  } else {
-    duk_push_string(ctx, "");
-  }
-
-  return 1;
-}
-
-duk_ret_t JSContext::native_innerHTML_set(duk_context *ctx) {
-  duk_push_global_stash(ctx);
-  duk_get_prop_string(ctx, -1, "js_context");
-  JSContext *self = static_cast<JSContext *>(duk_get_pointer(ctx, -1));
-  duk_pop_2(ctx);
-
-  if (!self)
-    return 0;
-
-  int handle = duk_to_int(ctx, 0);
-  const char *html_text = duk_to_string(ctx, 1);
-
-  Element *elt = self->get_element(handle);
-  if (!elt)
-    return 0;
-
-  elt->clearChildren();
-
-  std::string wrapped =
-      "<html><body>" + std::string(html_text) + "</body></html>";
-  HTMLParser parser(wrapped);
-  auto new_root = parser.parse();
-
-  if (new_root) {
-    // Find the <body> tag in the parsed tree
-    Element *body = nullptr;
-    std::vector<Element *> queue = {new_root.get()};
-    while (!queue.empty()) {
-      Element *curr = queue.front();
-      queue.erase(queue.begin());
-      if (curr->tag() == "body") {
-        body = curr;
-        break;
-      }
-      for (auto &child : curr->children()) {
-        if (child->type() == LexemeType::Element) {
-          queue.push_back(static_cast<Element *>(child.get()));
-        }
-      }
-    }
-
-    if (body) {
-      elt->moveChildrenFrom(body);
-    }
-  }
-
-  self->tab_->rebuild_layout();
-  return 0;
-}
-
 bool JSContext::dispatch_event(const std::string &type, Element *elt) {
-  if (!ctx_)
-    return false;
+  duk_get_global_string(ctx_, "dispatchEvent");
+  duk_push_string(ctx_, type.c_str());
+  duk_push_int(ctx_, get_handle(elt));
 
-  int handle = get_handle(elt);
-  std::string js =
-      "dispatchEvent('" + type + "', " + std::to_string(handle) + ")";
-
-  if (duk_peval_string(ctx_, js.c_str()) != 0) {
-    std::cerr << "Event " << type
-              << " crashed: " << duk_safe_to_string(ctx_, -1) << std::endl;
+  if (duk_pcall(ctx_, 2) != 0) {
+    std::cerr << "[JS] Event Dispatch Error: " << duk_safe_to_string(ctx_, -1)
+              << std::endl;
     duk_pop(ctx_);
     return false;
   }
 
-  bool prevent_default = duk_get_boolean(ctx_, -1);
+  bool preventDefault = duk_get_boolean(ctx_, -1);
   duk_pop(ctx_);
-  return prevent_default;
+  return preventDefault;
 }
 
 int JSContext::get_handle(Element *elt) {
   if (element_to_handle_.find(elt) != element_to_handle_.end()) {
     return element_to_handle_[elt];
   }
+
   int handle = static_cast<int>(handle_to_element_.size());
   element_to_handle_[elt] = handle;
   handle_to_element_.push_back(elt);
@@ -231,4 +86,87 @@ Element *JSContext::get_element(int handle) {
     return handle_to_element_[handle];
   }
   return nullptr;
+}
+
+duk_ret_t JSContext::native_print(duk_context *ctx) {
+  std::cout << "JS log: " << duk_safe_to_string(ctx, 0) << std::endl;
+  return 0;
+}
+
+duk_ret_t JSContext::native_querySelectorAll(duk_context *ctx) {
+  duk_push_global_stash(ctx);
+  duk_get_prop_string(ctx, -1, "js_context");
+  JSContext *self = static_cast<JSContext *>(duk_get_pointer(ctx, -1));
+  duk_pop_2(ctx);
+
+  const char *selector = duk_to_string(ctx, 0);
+  std::vector<Element *> results;
+  // TODO: results = self->tab_->root()->querySelectorAll(selector);
+  // (Simplified for now or use actual implementation)
+
+  duk_push_array(ctx);
+  for (size_t i = 0; i < results.size(); ++i) {
+    duk_push_int(ctx, self->get_handle(results[i]));
+    duk_put_prop_index(ctx, -2, static_cast<duk_uarridx_t>(i));
+  }
+  return 1;
+}
+
+duk_ret_t JSContext::native_getAttribute(duk_context *ctx) {
+  duk_push_global_stash(ctx);
+  duk_get_prop_string(ctx, -1, "js_context");
+  JSContext *self = static_cast<JSContext *>(duk_get_pointer(ctx, -1));
+  duk_pop_2(ctx);
+
+  int handle = duk_to_int(ctx, 0);
+  const char *attr = duk_to_string(ctx, 1);
+
+  Element *el = self->get_element(handle);
+  if (el && el->attributes().count(attr)) {
+    duk_push_string(ctx, el->attributes().at(attr).c_str());
+  } else {
+    duk_push_null(ctx);
+  }
+  return 1;
+}
+
+duk_ret_t JSContext::native_innerHTML_set(duk_context *ctx) {
+  duk_push_global_stash(ctx);
+  duk_get_prop_string(ctx, -1, "js_context");
+  JSContext *self = static_cast<JSContext *>(duk_get_pointer(ctx, -1));
+  duk_pop_2(ctx);
+
+  int handle = duk_to_int(ctx, 0);
+  const char *html = duk_to_string(ctx, 1);
+
+  Element *el = self->get_element(handle);
+  if (el) {
+    // el->set_inner_html(html);
+    // self->tab_->rebuild_layout();
+  }
+  return 0;
+}
+
+duk_ret_t JSContext::native_XMLHttpRequest_send(duk_context *ctx) {
+  duk_push_global_stash(ctx);
+  duk_get_prop_string(ctx, -1, "js_context");
+  JSContext *self = static_cast<JSContext *>(duk_get_pointer(ctx, -1));
+  duk_pop_2(ctx);
+
+  if (!self || !self->tab_)
+    return 0;
+
+  const char *method = duk_to_string(ctx, 0);
+  const char *url_str = duk_to_string(ctx, 1);
+  const char *body = duk_to_string(ctx, 2);
+
+  Url target_url = self->tab_->url().resolve(url_str);
+
+  // Phase 2: NO SECURITY CHECKS (Vulnerability demonstration)
+  std::cout << "[JS XHR] Sending " << method << " request to "
+            << target_url.href() << std::endl;
+  auto response = self->tab_->http()->request(target_url, body);
+
+  duk_push_string(ctx, response.body.c_str());
+  return 1;
 }

--- a/src/js/JSContext.h
+++ b/src/js/JSContext.h
@@ -25,6 +25,8 @@ private:
   static duk_ret_t native_getAttribute(duk_context *ctx);
   static duk_ret_t native_innerHTML_set(duk_context *ctx);
   static duk_ret_t native_XMLHttpRequest_send(duk_context *ctx);
+  static duk_ret_t native_cookie_get(duk_context *ctx);
+  static duk_ret_t native_cookie_set(duk_context *ctx);
 
   Tab *tab_;
   duk_context *ctx_;

--- a/src/js/JSContext.h
+++ b/src/js/JSContext.h
@@ -24,6 +24,7 @@ private:
   static duk_ret_t native_querySelectorAll(duk_context *ctx);
   static duk_ret_t native_getAttribute(duk_context *ctx);
   static duk_ret_t native_innerHTML_set(duk_context *ctx);
+  static duk_ret_t native_XMLHttpRequest_send(duk_context *ctx);
 
   Tab *tab_;
   duk_context *ctx_;

--- a/src/layout/BlockLayout.cpp
+++ b/src/layout/BlockLayout.cpp
@@ -216,6 +216,7 @@ void BlockLayout::layoutNode(const Lexeme *node) {
         new_line();
       } else if (el->tag() == "input" || el->tag() == "button") {
         input(el);
+        return; // Atomic widget handling
       }
     }
     layoutElement(el);

--- a/src/request/CookieJar.cpp
+++ b/src/request/CookieJar.cpp
@@ -1,0 +1,143 @@
+#include "CookieJar.h"
+#include "url/Url.h"
+#include <algorithm>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+namespace {
+const std::string COOKIE_FILE = ".csurfer_cookies";
+
+std::string to_lower(std::string s) {
+  std::transform(s.begin(), s.end(), s.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+  return s;
+}
+} // namespace
+
+CookieJar::CookieJar() { load_from_disk(); }
+
+void CookieJar::store_cookie(const Url &url,
+                             const std::string &set_cookie_header) {
+  std::stringstream ss(set_cookie_header);
+  std::string part;
+  Cookie cookie;
+  cookie.domain = url.host();
+
+  bool first = true;
+  while (std::getline(ss, part, ';')) {
+    // Trim
+    part.erase(0, part.find_first_not_of(" "));
+    part.erase(part.find_last_not_of(" ") + 1);
+
+    auto eq = part.find('=');
+    if (first) {
+      if (eq != std::string::npos) {
+        cookie.name = part.substr(0, eq);
+        cookie.value = part.substr(eq + 1);
+      }
+      first = false;
+    } else {
+      std::string key = (eq == std::string::npos) ? part : part.substr(0, eq);
+      std::string val = (eq == std::string::npos) ? "" : part.substr(eq + 1);
+      key = to_lower(key);
+
+      if (key == "domain")
+        cookie.domain = val;
+      else if (key == "path")
+        cookie.path = val;
+      else if (key == "samesite")
+        cookie.same_site = to_lower(val);
+    }
+  }
+
+  if (!cookie.name.empty()) {
+    // For simplicity, overwrite if name exists for this domain
+    auto &domain_cookies = cookies_[cookie.domain];
+    auto it =
+        std::find_if(domain_cookies.begin(), domain_cookies.end(),
+                     [&](const Cookie &c) { return c.name == cookie.name; });
+
+    if (it != domain_cookies.end()) {
+      *it = cookie;
+    } else {
+      domain_cookies.push_back(cookie);
+    }
+    save_to_disk();
+  }
+}
+
+std::string CookieJar::get_cookies(const Url &target_url,
+                                   const Url &referrer_url,
+                                   const std::string &method) const {
+  std::string host = target_url.host();
+  if (cookies_.count(host) == 0)
+    return "";
+
+  std::string cookie_string;
+  const auto &domain_cookies = cookies_.at(host);
+
+  for (const auto &cookie : domain_cookies) {
+    bool allow = true;
+
+    // SameSite=Lax enforcement
+    if (cookie.same_site == "lax") {
+      // If cross-origin and NOT a GET request, block the cookie (CSRF
+      // prevention)
+      if (!referrer_url.origin().empty() &&
+          referrer_url.origin() != target_url.origin()) {
+        if (method != "GET") {
+          allow = false;
+        }
+      }
+    } else if (cookie.same_site == "strict") {
+      if (referrer_url.origin() != target_url.origin()) {
+        allow = false;
+      }
+    }
+
+    if (allow) {
+      if (!cookie_string.empty())
+        cookie_string += "; ";
+      cookie_string += cookie.name + "=" + cookie.value;
+    }
+  }
+
+  return cookie_string;
+}
+
+void CookieJar::save_to_disk() const {
+  std::ofstream f(COOKIE_FILE);
+  if (!f.is_open())
+    return;
+
+  for (const auto &[domain, domain_cookies] : cookies_) {
+    for (const auto &cookie : domain_cookies) {
+      f << domain << "|" << cookie.name << "|" << cookie.value << "|"
+        << cookie.same_site << "|" << cookie.path << "\n";
+    }
+  }
+}
+
+void CookieJar::load_from_disk() {
+  std::ifstream f(COOKIE_FILE);
+  if (!f.is_open())
+    return;
+
+  std::string line;
+  while (std::getline(f, line)) {
+    std::stringstream ss(line);
+    std::string domain, name, value, samesite, path;
+    if (std::getline(ss, domain, '|') && std::getline(ss, name, '|') &&
+        std::getline(ss, value, '|') && std::getline(ss, samesite, '|') &&
+        std::getline(ss, path)) {
+      Cookie cookie;
+      cookie.domain = domain;
+      cookie.name = name;
+      cookie.value = value;
+      cookie.same_site = samesite;
+      cookie.path = path;
+      cookies_[domain].push_back(cookie);
+    }
+  }
+}

--- a/src/request/CookieJar.h
+++ b/src/request/CookieJar.h
@@ -1,0 +1,40 @@
+#pragma once
+#include <map>
+#include <string>
+#include <vector>
+
+class Url;
+
+struct Cookie {
+  std::string name;
+  std::string value;
+  std::string domain;
+  std::string path = "/";
+  std::string same_site = "lax"; // lax, strict, none
+};
+
+/**
+ * Handles storage and retrieval of HTTP cookies with SameSite enforcement.
+ */
+class CookieJar {
+public:
+  CookieJar();
+  /**
+   * Parse a Set-Cookie header and store the cookie.
+   */
+  void store_cookie(const Url &url, const std::string &set_cookie_header);
+
+  /**
+   * Retrieve all matching cookies for a request, formatted as a "Cookie" header
+   * value.
+   * Checks SameSite=Lax restrictions based on the referrer and method.
+   */
+  std::string get_cookies(const Url &target_url, const Url &referrer_url,
+                          const std::string &method) const;
+
+private:
+  void save_to_disk() const;
+  void load_from_disk();
+
+  std::map<std::string, std::vector<Cookie>> cookies_;
+};

--- a/src/request/HttpRequest.cpp
+++ b/src/request/HttpRequest.cpp
@@ -1,4 +1,5 @@
 #include "HttpRequest.h"
+#include "CookieJar.h"
 #include "url/Url.h"
 
 #include <algorithm>
@@ -13,7 +14,8 @@
 #include <unistd.h>
 
 // Berkeley sockets wrapper
-HttpResponse HttpRequest::request(const Url &url, const std::string &payload) {
+HttpResponse HttpRequest::request(const Url &url, const std::string &payload,
+                                  const Url &referrer) {
   int sock = socket(AF_INET, SOCK_STREAM, 0);
   if (sock < 0)
     return {};
@@ -59,6 +61,17 @@ HttpResponse HttpRequest::request(const Url &url, const std::string &payload) {
   std::string method = payload.empty() ? "GET" : "POST";
   std::string req = method + " " + url.path() + " HTTP/1.0\r\n" +
                     "Host: " + url.host() + "\r\n";
+
+  if (cookie_jar_) {
+    std::string cookies = cookie_jar_->get_cookies(url, referrer, method);
+    if (!cookies.empty()) {
+      req += "Cookie: " + cookies + "\r\n";
+    }
+  }
+
+  if (!referrer.host().empty()) {
+    req += "Referer: " + referrer.origin() + "\r\n";
+  }
 
   if (!payload.empty()) {
     req += "Content-Type: application/x-www-form-urlencoded\r\n";
@@ -138,5 +151,21 @@ HttpResponse HttpRequest::request(const Url &url, const std::string &payload) {
     }
   }
 
+  if (cookie_jar_ && res.headers.count("set-cookie")) {
+    cookie_jar_->store_cookie(url, res.headers.at("set-cookie"));
+  }
+
   return res;
+}
+
+std::string HttpRequest::get_cookies(const Url &url) {
+  if (!cookie_jar_)
+    return "";
+  return cookie_jar_->get_cookies(url, url, "GET");
+}
+
+void HttpRequest::set_cookie(const Url &url, const std::string &value) {
+  if (cookie_jar_) {
+    cookie_jar_->store_cookie(url, value);
+  }
 }

--- a/src/request/HttpRequest.cpp
+++ b/src/request/HttpRequest.cpp
@@ -1,24 +1,27 @@
 #include "HttpRequest.h"
 #include "url/Url.h"
 
+#include <algorithm>
 #include <arpa/inet.h>
+#include <cctype>
 #include <cstring>
 #include <netdb.h>
 #include <openssl/err.h>
 #include <openssl/ssl.h>
+#include <sstream>
 #include <sys/socket.h>
 #include <unistd.h>
 
 // Berkeley sockets wrapper
-std::string HttpRequest::request(const Url &url, const std::string &payload) {
+HttpResponse HttpRequest::request(const Url &url, const std::string &payload) {
   int sock = socket(AF_INET, SOCK_STREAM, 0);
   if (sock < 0)
-    return "";
+    return {};
 
   hostent *server = gethostbyname(url.host().c_str());
   if (!server) {
     close(sock);
-    return "";
+    return {};
   }
 
   sockaddr_in addr{};
@@ -28,7 +31,7 @@ std::string HttpRequest::request(const Url &url, const std::string &payload) {
 
   if (connect(sock, (sockaddr *)&addr, sizeof(addr)) < 0) {
     close(sock);
-    return "";
+    return {};
   }
 
   SSL_CTX *ctx = nullptr;
@@ -47,7 +50,7 @@ std::string HttpRequest::request(const Url &url, const std::string &payload) {
       SSL_free(ssl);
       SSL_CTX_free(ctx);
       close(sock);
-      return "";
+      return {};
     }
   }
 
@@ -93,6 +96,47 @@ std::string HttpRequest::request(const Url &url, const std::string &payload) {
 
   close(sock);
 
+  HttpResponse res;
   auto pos = response.find("\r\n\r\n");
-  return (pos != std::string::npos) ? response.substr(pos + 4) : response;
+  if (pos == std::string::npos) {
+    res.body = response;
+    return res;
+  }
+
+  std::string header_part = response.substr(0, pos);
+  res.body = response.substr(pos + 4);
+
+  std::istringstream stream(header_part);
+  std::string line;
+  if (std::getline(stream, line)) {
+    // Skip status line (e.g., HTTP/1.0 200 OK)
+  }
+
+  while (std::getline(stream, line) && line != "\r") {
+    auto colon = line.find(':');
+    if (colon != std::string::npos) {
+      std::string key = line.substr(0, colon);
+      std::string value = line.substr(colon + 1);
+
+      // Trim whitespace and carriage return
+      auto trim = [](std::string &s) {
+        s.erase(0, s.find_first_not_of(" \t"));
+        auto end = s.find_last_not_of(" \r\t");
+        if (end != std::string::npos)
+          s.erase(end + 1);
+        else
+          s.clear();
+      };
+
+      trim(key);
+      trim(value);
+
+      // Normalize key to lowercase
+      std::transform(key.begin(), key.end(), key.begin(),
+                     [](unsigned char c) { return std::tolower(c); });
+      res.headers[key] = value;
+    }
+  }
+
+  return res;
 }

--- a/src/request/HttpRequest.h
+++ b/src/request/HttpRequest.h
@@ -1,11 +1,20 @@
 #pragma once
 #include "IRequest.h"
 
+class CookieJar;
+
 class HttpRequest : public IRequest {
 public:
   /**
    * Implementation of HTTP GET/POST request.
    */
-  HttpResponse request(const Url &url,
-                       const std::string &payload = "") override;
+  HttpResponse request(const Url &url, const std::string &payload = "",
+                       const Url &referrer = {}) override;
+
+  void set_cookie_jar(CookieJar *jar) override { cookie_jar_ = jar; }
+  std::string get_cookies(const Url &url) override;
+  void set_cookie(const Url &url, const std::string &value) override;
+
+private:
+  CookieJar *cookie_jar_ = nullptr;
 };

--- a/src/request/HttpRequest.h
+++ b/src/request/HttpRequest.h
@@ -6,5 +6,6 @@ public:
   /**
    * Implementation of HTTP GET/POST request.
    */
-  std::string request(const Url &url, const std::string &payload = "") override;
+  HttpResponse request(const Url &url,
+                       const std::string &payload = "") override;
 };

--- a/src/request/IRequest.h
+++ b/src/request/IRequest.h
@@ -1,7 +1,13 @@
 #pragma once
+#include <map>
 #include <string>
 
 class Url;
+
+struct HttpResponse {
+  std::map<std::string, std::string> headers;
+  std::string body;
+};
 
 class IRequest {
 public:
@@ -9,6 +15,6 @@ public:
   /**
    * Request a page from a URL, optionally sending a POST payload.
    */
-  virtual std::string request(const Url &url,
-                              const std::string &payload = "") = 0;
+  virtual HttpResponse request(const Url &url,
+                               const std::string &payload = "") = 0;
 };

--- a/src/request/IRequest.h
+++ b/src/request/IRequest.h
@@ -2,19 +2,37 @@
 #include <map>
 #include <string>
 
-class Url;
+#include "url/Url.h"
 
 struct HttpResponse {
   std::map<std::string, std::string> headers;
   std::string body;
 };
 
+class CookieJar;
+
 class IRequest {
 public:
   virtual ~IRequest() = default;
   /**
    * Request a page from a URL, optionally sending a POST payload.
+   * referrer is used for SameSite cookie policy and Referer header.
    */
-  virtual HttpResponse request(const Url &url,
-                               const std::string &payload = "") = 0;
+  virtual HttpResponse request(const Url &url, const std::string &payload = "",
+                               const Url &referrer = {}) = 0;
+
+  /**
+   * Associate a CookieJar with this request engine.
+   */
+  virtual void set_cookie_jar(CookieJar *jar) = 0;
+
+  /**
+   * Get cookies formatted for JavaScript document.cookie.
+   */
+  virtual std::string get_cookies(const Url &url) = 0;
+
+  /**
+   * Store a cookie from JavaScript document.cookie = "...".
+   */
+  virtual void set_cookie(const Url &url, const std::string &value) = 0;
 };

--- a/src/url/Url.cpp
+++ b/src/url/Url.cpp
@@ -58,6 +58,10 @@ std::string Url::href() const {
   return result;
 }
 
+std::string Url::origin() const {
+  return scheme_ + "://" + host_ + ":" + port_;
+}
+
 Url Url::resolve(const std::string &href) const {
   if (href.find("://") != std::string::npos) {
     return Url(href);

--- a/src/url/Url.h
+++ b/src/url/Url.h
@@ -11,6 +11,7 @@ public:
   const std::string &port() const;
 
   std::string href() const;
+  std::string origin() const;
 
   Url resolve(const std::string &href) const;
 

--- a/src/url/Url.h
+++ b/src/url/Url.h
@@ -3,6 +3,7 @@
 
 class Url {
 public:
+  Url() = default;
   explicit Url(const std::string &raw);
 
   const std::string &scheme() const;

--- a/unit-tests/test_url_origin.cpp
+++ b/unit-tests/test_url_origin.cpp
@@ -1,0 +1,56 @@
+#include "request/IRequest.h"
+#include "url/Url.h"
+#include <iostream>
+#include <map>
+#include <string>
+#include <vector>
+
+struct TestCase {
+  std::string url;
+  std::string expected_origin;
+};
+
+int main() {
+  std::vector<TestCase> cases = {
+      {"https://google.com/search?q=test", "https://google.com:443"},
+      {"http://example.com/", "http://example.com:80"},
+      {"http://localhost:8080/path", "http://localhost:8080"},
+      {"https://my-site.org:1234/test", "https://my-site.org:1234"},
+      {"about:welcome", "about://:"} // 'about' scheme doesn't have a host/port
+  };
+
+  int failed = 0;
+  std::cout << "--- Running URL Origin Tests ---" << std::endl;
+
+  for (const auto &tc : cases) {
+    Url u(tc.url);
+    std::string actual = u.origin();
+    if (actual == tc.expected_origin) {
+      std::cout << "SUCCESS: " << tc.url << " -> " << actual << std::endl;
+    } else {
+      std::cout << "FAILURE: " << tc.url
+                << "\n  Expected: " << tc.expected_origin
+                << "\n  Actual:   " << actual << std::endl;
+      failed++;
+    }
+  }
+
+  std::cout << "\n--- HttpResponse Structure Test ---" << std::endl;
+  HttpResponse res;
+  res.body = "test body";
+  res.headers["content-type"] = "text/html";
+  if (res.headers.size() == 1 && res.headers["content-type"] == "text/html") {
+    std::cout << "SUCCESS: HttpResponse headers verified." << std::endl;
+  } else {
+    std::cout << "FAILURE: HttpResponse headers mismatch." << std::endl;
+    failed++;
+  }
+
+  if (failed == 0) {
+    std::cout << "\nALL TESTS PASSED!" << std::endl;
+    return 0;
+  } else {
+    std::cout << "\n" << failed << " TEST(S) FAILED!" << std::endl;
+    return 1;
+  }
+}


### PR DESCRIPTION
fix #19 

This work completes the comprehensive security hardening of CSurfer, moving the browser from an open, vulnerable state to a modern defense-in-depth model across 5 implementation phases.

- Phase 1 & 2 (Foundation): Implemented robust HTTP response header parsing and origin-based identification.
- Phase 3 (SOP): Enforced the Same-Origin Policy for XMLHttpRequest, preventing cross-origin exfiltration.
- Phase 4 (CSP): Added Content Security Policy enforcement to whitelist authorized scripts and styles.
- Phase 5 (Cookies & CSRF): Implemented a stateful CookieJar with SameSite=Lax enforcement and persistence.
- Persistence: Added disk-based serialization to .csurfer_cookies to maintain sessions across restarts.
- Stability: Resolved major regressions in HTML parsing (script tags) and UI rendering (duplicate buttons).
- Quality: Added automated linting via clang-tidy and updated all architectural documentation.
