### PR TITLE
feat(build): modernize developer workflow and enhance DX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ external
 notes/
 learn/
 .csurfer_cookies
+compile_commands.json

--- a/README.md
+++ b/README.md
@@ -20,13 +20,18 @@ sudo apt install build-essential cmake libssl-dev libsdl2-ttf-dev libfreetype-de
 
 ### Build
 
+**Recommended method (using scripts):**
 ```bash
-mkdir build && cd build
-cmake ..
-make -j8
+./scripts/rebuild.sh   # Configures and builds using Clang++ & Ninja
 ```
 
-The executable `c_surfer` will be in the `build/` directory.
+**Manual method (using Presets):**
+```bash
+cmake --preset default
+cmake --build --preset default
+```
+
+The executable `c_surfer` will be located in the `build/` directory.
 
 ## Usage
 
@@ -72,17 +77,14 @@ See `pages/` directory for sample HTML files, including Chapter 8 interactive te
 
 ## Development
 
-### Formatting
-CSurfer uses `clang-format` to maintain a consistent coding style.
-```bash
-./scripts/format.sh
-```
+### Development Scripts
+*   **`./scripts/rebuild.sh`**: Performs an incremental build, preserves the CMake cache, and symlinks `compile_commands.json` to the root for LSP support.
+*   **`./scripts/dev.sh`**: Builds the project and immediately launches the browser.
+*   **`./scripts/format.sh`**: Runs `clang-format` on all source files.
+*   **`./scripts/lint.sh`**: Runs `clang-tidy` (requires `compile_commands.json`).
 
-### Linting
-To check for logical errors, performance issues, and code quality, run the linter script (requires `clang-tidy` and `build/compile_commands.json`).
-```bash
-./scripts/lint.sh
-```
+### LSP / IDE Support
+The root `compile_commands.json` is automatically managed by the build scripts. If you use `clangd` or VS Code, it should work out of the box.
 
 ## License
 

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Exit on error
+set -e
+
+# Get the script directory and move to project root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
+# Run the rebuild script
+./scripts/rebuild.sh
+
+echo "Launching c_surfer..."
+./build/c_surfer "$@"

--- a/scripts/rebuild.sh
+++ b/scripts/rebuild.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Exit on error
+set -e
+
+# Get the script directory and move to project root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
+# We are not removing the build directory here to preserve the CMake cache.
+# If you need a fully clean state, use 'cmake --build --preset default --target clean' instead.
+
+echo "Configuring with preset 'default'..."
+cmake --preset default
+
+echo "Building with preset 'default'..."
+cmake --build --preset default
+
+# Create symlink for compile_commands.json to help LSP (clangd, etc.)
+if [ -f "build/compile_commands.json" ]; then
+    ln -sf build/compile_commands.json .
+    echo "Symlinked compile_commands.json to root."
+fi
+
+echo "Rebuild complete!"


### PR DESCRIPTION
- Add `scripts/rebuild.sh` for fast incremental builds and LSP support.
- Add `scripts/dev.sh` to rebuild and launch the browser in one command.
- Automate `compile_commands.json` symlinking to the root for better IDE indexing.
- Update `.gitignore` to exclude machine-specific build metadata.
- Update `README.md` with new build instructions and development guide.

This change streamlines the development process by reducing manual CMake steps and ensuring language servers (like clangd) work out of the box.

fix #21 