### PR TITLE
feat(build): rename binary from c_surfer to csurfer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,7 +140,7 @@ endif()
 # ------------------------------------------------------------------------------
 # Main executable
 # ------------------------------------------------------------------------------
-add_executable(c_surfer
+add_executable(csurfer
     src/main.cpp
     src/lexer/Lexeme.cpp
     src/lexer/Text.cpp
@@ -167,11 +167,11 @@ add_executable(c_surfer
 )
 
 # Add include directories for src/
-target_include_directories(c_surfer PRIVATE
+target_include_directories(csurfer PRIVATE
     ${PROJECT_SOURCE_DIR}/src
 )
 
-target_link_libraries(c_surfer PRIVATE
+target_link_libraries(csurfer PRIVATE
     project_warnings
     # skia
     SDL2::SDL2
@@ -187,7 +187,7 @@ target_link_libraries(c_surfer PRIVATE
 # ------------------------------------------------------------------------------
 
 # Assuming your assets folder is at project-root/assets
-target_compile_definitions(c_surfer PRIVATE
+target_compile_definitions(csurfer PRIVATE
     ASSETS_DIR="${PROJECT_SOURCE_DIR}/assets"
 )
 
@@ -195,12 +195,12 @@ target_compile_definitions(c_surfer PRIVATE
 # Logging configuration (compile-time)
 # ------------------------------------------------------------------------------
 if (ENABLE_LOGGING)
-    target_compile_definitions(c_surfer PRIVATE
+    target_compile_definitions(csurfer PRIVATE
         ENABLE_LOGGING=1
         LOG_LEVEL_${LOG_LEVEL}=1
     )
     message(STATUS "Logging enabled (level: ${LOG_LEVEL})")
 else()
-    target_compile_definitions(c_surfer PRIVATE ENABLE_LOGGING=0)
+    target_compile_definitions(csurfer PRIVATE ENABLE_LOGGING=0)
     message(STATUS "Logging disabled")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.28)
 
 project(
-    c_surfer
+    csurfer
     VERSION 0.1.0
     LANGUAGES C CXX
 )

--- a/README.md
+++ b/README.md
@@ -31,15 +31,15 @@ cmake --preset default
 cmake --build --preset default
 ```
 
-The executable `c_surfer` will be located in the `build/` directory.
+The executable `csurfer` will be located in the `build/` directory.
 
 ## Usage
 
 **Run anytime** - Launch the browser without arguments to see the welcome page, or pass a URL.
 
 ```bash
-./c_surfer                     # Opens about:welcome
-./c_surfer https://example.com  # Opens a specific site
+./csurfer                     # Opens about:welcome
+./csurfer https://example.com  # Opens a specific site
 ```
 
 The browser opens an 800x600 window.
@@ -70,7 +70,7 @@ Fonts are loaded from `assets/fonts/`. Modify `Browser.cpp` to change window siz
 ./scripts/run_server.sh
 
 # Then browse
-./build/c_surfer http://localhost:8000/ch8-login.html
+./build/csurfer http://localhost:8000/ch8-login.html
 ```
 
 See `pages/` directory for sample HTML files, including Chapter 8 interactive tests.

--- a/config/vscode/launch.json
+++ b/config/vscode/launch.json
@@ -2,11 +2,13 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Debug c_surfer (GDB)",
+            "name": "Debug csurfer (GDB)",
             "type": "cppdbg",
             "request": "launch",
-            "program": "${workspaceFolder}/build/c_surfer",
-            "args": ["http://127.0.0.1:8000/styled.html"],
+            "program": "${workspaceFolder}/build/csurfer",
+            "args": [
+                "http://127.0.0.1:8000/styled.html"
+            ],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}",
             "environment": [],
@@ -28,11 +30,13 @@
             "miDebuggerPath": "/usr/bin/gdb"
         },
         {
-            "name": "Debug c_surfer (LLDB)",
+            "name": "Debug csurfer (LLDB)",
             "type": "cppdbg",
             "request": "launch",
-            "program": "${workspaceFolder}/build/c_surfer",
-            "args": ["http://127.0.0.1:8000/styled.html"],
+            "program": "${workspaceFolder}/build/csurfer",
+            "args": [
+                "http://127.0.0.1:8000/styled.html"
+            ],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}",
             "environment": [],
@@ -55,4 +59,3 @@
         }
     ]
 }
-

--- a/docs/chapter10_demo.md
+++ b/docs/chapter10_demo.md
@@ -14,7 +14,7 @@ This document provides instructions for verifying the security features implemen
 ### Execution
 Run the following command:
 ```bash
-./build/c_surfer http://localhost:8000/bank_protected.html
+./build/csurfer http://localhost:8000/bank_protected.html
 ```
 
 ### Expected Result
@@ -32,21 +32,21 @@ Run the following command:
 ### Step 1: Login (Legitimate Session)
 Run the following command to log in and set a `SameSite=Lax` cookie:
 ```bash
-./build/c_surfer http://localhost:8000/login
+./build/csurfer http://localhost:8000/login
 ```
 *Result: Status should say "Login Successful".*
 
 ### Step 2: Verify Session Persistence
 Access your account page to confirm the cookie is being sent on same-origin requests:
 ```bash
-./build/c_surfer http://localhost:8000/bank_session.html
+./build/csurfer http://localhost:8000/bank_session.html
 ```
 *Result: Status should say "Status: Logged In (Session: Active)".*
 
 ### Step 3: Trigger the Attack (Cross-Origin POST)
 Simulate visiting a malicious site that tries to transfer money from your bank:
 ```bash
-./build/c_surfer http://localhost:8001/csrf_attacker.html
+./build/csurfer http://localhost:8001/csrf_attacker.html
 ```
 Click the **"CLAIM PRIZE NOW!"** button.
 

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -10,5 +10,5 @@ cd "$SCRIPT_DIR/.."
 # Run the rebuild script
 ./scripts/rebuild.sh
 
-echo "Launching c_surfer..."
-./build/c_surfer "$@"
+echo "Launching csurfer..."
+./build/csurfer "$@"


### PR DESCRIPTION
This change synchronizes the project branding and executable naming 
across the entire repository, removing the legacy 'c_surfer' name.
Key Changes:
- CMakeLists.txt: Renamed `project()` and main `add_executable` target.
- Scripts: Updated `dev.sh` to launch the renamed binary path.
- Documentation: Updated `README.md` and `docs/chapter10_demo.md` with accurate command-line examples.
- IDE Support: Migrated VS Code `launch.json` configurations (GDB/LLDB) to use the new binary name.
- Git Hygiene: Maintained consistency in build artifact exclusion. This migration ensures a more intuitive command-line experience and consistency between the repository name and the output binary.

fix #23 